### PR TITLE
feat: 관리자 페이지 고객 관리 메뉴 UI 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,14 +7,13 @@
   "extends": [
     "next/core-web-vitals",
     "plugin:@typescript-eslint/recommended",
-    "plugin:react-hooks/recommended",
     "plugin:import/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:react/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "react-refresh", "react", "import", "prettier", "@emotion"],
   "rules": {
-    "@emotion/no-vanilla": "warn",
     "@emotion/syntax-preference": ["error", "string"],
     "react-refresh/only-export-components": [
       "warn",
@@ -34,6 +33,17 @@
         "namedComponents": "arrow-function"
       }
     ],
+    "@typescript-eslint/no-restricted-types": [
+      "error",
+      {
+        "types": {
+          "React.FC": {
+            "message": "Do not use React.FC😭"
+          }
+        }
+      }
+    ],
+    "import/no-unresolved": "off",
     "import/order": [
       "error",
       {
@@ -58,11 +68,17 @@
         }
       }
     ],
-    "@typescript-eslint/no-unused-vars": "warn"
+    "@typescript-eslint/no-unused-vars": "warn",
+    "react/react-in-jsx-scope": "off"
   },
   "settings": {
     "import/resolver": {
-      "typescript": {}
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    },
+    "react": {
+      "version": "detect"
     }
   },
   "ignorePatterns": ["dist", ".eslintrc.cjs"]

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.0.1",
     "@tanstack/react-query": "^5.74.7",
+    "antd": "^5.25.1",
     "apexcharts": "^4.7.0",
     "axios": "^1.9.0",
+    "dayjs": "^1.11.13",
     "next": "14.2.28",
     "react": "^18",
     "react-apexcharts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,19 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@emotion/eslint-plugin": "^11.12.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@typescript-eslint/eslint-plugin": "^8.31.0",
-    "@typescript-eslint/parser": "^8.31.0",
+    "@typescript-eslint/eslint-plugin": "^8.32.0",
+    "@typescript-eslint/parser": "^8.32.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.28",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-import-resolver-node": "^0.3.9",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.6",
+    "eslint-plugin-react-refresh": "^0.4.20",
     "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@emotion/css':
+        specifier: ^11.13.5
+        version: 11.13.5
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@18.3.21)(react@18.3.1)
@@ -19,13 +22,19 @@ importers:
         version: 5.0.1(react-hook-form@7.56.3(react@18.3.1))
       '@tanstack/react-query':
         specifier: ^5.74.7
-        version: 5.75.5(react@18.3.1)
+        version: 5.75.7(react@18.3.1)
+      antd:
+        specifier: ^5.25.1
+        version: 5.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       apexcharts:
         specifier: ^4.7.0
         version: 4.7.0
       axios:
         specifier: ^1.9.0
         version: 1.9.0
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       next:
         specifier: 14.2.28
         version: 14.2.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -48,6 +57,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.4(@types/react@18.3.21)(react@18.3.1)
     devDependencies:
+      '@emotion/eslint-plugin':
+        specifier: ^11.12.0
+        version: 11.12.0(eslint@8.57.1)(typescript@5.8.3)
       '@types/node':
         specifier: ^20
         version: 20.17.46
@@ -58,10 +70,10 @@ importers:
         specifier: ^18
         version: 18.3.7(@types/react@18.3.21)
       '@typescript-eslint/eslint-plugin':
-        specifier: ^8.31.0
+        specifier: ^8.32.0
         version: 8.32.0(@typescript-eslint/parser@8.32.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
-        specifier: ^8.31.0
+        specifier: ^8.32.0
         version: 8.32.0(eslint@8.57.1)(typescript@5.8.3)
       eslint:
         specifier: ^8
@@ -72,17 +84,57 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.2
         version: 10.1.5(eslint@8.57.1)
+      eslint-import-resolver-node:
+        specifier: ^0.3.9
+        version: 0.3.9
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.32.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.2.6
         version: 5.4.0(eslint-config-prettier@10.1.5(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.20
+        version: 0.4.20(eslint@8.57.1)
       typescript:
         specifier: ^5
         version: 5.8.3
 
 packages:
+
+  '@ant-design/colors@7.2.0':
+    resolution: {integrity: sha512-bjTObSnZ9C/O8MB/B4OUtd/q9COomuJAR2SYfhxLyHvCKn4EKwCN3e+fWGMo7H5InAyV0wL17jdE9ALrdOW/6A==}
+
+  '@ant-design/cssinjs-utils@1.1.3':
+    resolution: {integrity: sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@ant-design/cssinjs@1.23.0':
+    resolution: {integrity: sha512-7GAg9bD/iC9ikWatU9ym+P9ugJhi/WbsTWzcKN6T4gU0aehsprtke1UAaaSxxkjjmkJb3llet/rbUSLPgwlY4w==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  '@ant-design/fast-color@2.0.6':
+    resolution: {integrity: sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==}
+    engines: {node: '>=8.x'}
+
+  '@ant-design/icons-svg@4.4.2':
+    resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
+
+  '@ant-design/icons@5.6.1':
+    resolution: {integrity: sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  '@ant-design/react-slick@1.1.2':
+    resolution: {integrity: sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==}
+    peerDependencies:
+      react: '>=16.9.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -140,6 +192,18 @@ packages:
   '@emotion/cache@11.14.0':
     resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
 
+  '@emotion/css@11.13.5':
+    resolution: {integrity: sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==}
+
+  '@emotion/eslint-plugin@11.12.0':
+    resolution: {integrity: sha512-N0rtAVKk6w8RchWtexdG/GFbg48tdlO4cnq9Jg6H3ul3EDDgkYkPE0PKMb1/CJ7cDyYsiNPYVc3ZnWnd2/d0tA==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      eslint: 6 || 7 || 8
+
+  '@emotion/hash@0.8.0':
+    resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
+
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
@@ -176,6 +240,9 @@ packages:
 
   '@emotion/unitless@0.10.0':
     resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/unitless@0.7.5':
+    resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
 
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
     resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
@@ -333,6 +400,61 @@ packages:
     resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@rc-component/async-validator@5.0.4':
+    resolution: {integrity: sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==}
+    engines: {node: '>=14.x'}
+
+  '@rc-component/color-picker@2.0.1':
+    resolution: {integrity: sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/context@1.4.0':
+    resolution: {integrity: sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/mini-decimal@1.1.0':
+    resolution: {integrity: sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==}
+    engines: {node: '>=8.x'}
+
+  '@rc-component/mutate-observer@1.1.0':
+    resolution: {integrity: sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/portal@1.1.2':
+    resolution: {integrity: sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/qrcode@1.0.0':
+    resolution: {integrity: sha512-L+rZ4HXP2sJ1gHMGHjsg9jlYBX/SLN2D6OxP9Zn3qgtpMWtO2vUfxVFwiogHpAIqs54FnALxraUy/BCO1yRIgg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/tour@1.15.1':
+    resolution: {integrity: sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/trigger@2.2.6':
+    resolution: {integrity: sha512-/9zuTnWwhQ3S3WT1T8BubuFTT46kvnXgaERR9f4BTKyn61/wpf/BvbImzYBubzJibU707FxwbKszLlHjcLiv1Q==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -373,16 +495,19 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
-  '@tanstack/query-core@5.75.5':
-    resolution: {integrity: sha512-kPDOxtoMn2Ycycb76Givx2fi+2pzo98F9ifHL/NFiahEDpDwSVW6o12PRuQ0lQnBOunhRG5etatAhQij91M3MQ==}
+  '@tanstack/query-core@5.75.7':
+    resolution: {integrity: sha512-4BHu0qnxUHOSnTn3ow9fIoBKTelh0GY08yn1IO9cxjBTsGvnxz1ut42CHZqUE3Vl/8FAjcHsj8RNJMoXvjgHEA==}
 
-  '@tanstack/react-query@5.75.5':
-    resolution: {integrity: sha512-QrLCJe40BgBVlWdAdf2ZEVJ0cISOuEy/HKupId1aTKU6gPJZVhSvZpH+Si7csRflCJphzlQ77Yx6gUxGW9o0XQ==}
+  '@tanstack/react-query@5.75.7':
+    resolution: {integrity: sha512-JYcH1g5pNjKXNQcvvnCU/PueaYg05uKBDHlWIyApspv7r5C0BM12n6ysa2QF2T+1tlPnNXOob8vr8o96Nx0GxQ==}
     peerDependencies:
       react: ^18 || ^19
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -404,6 +529,9 @@ packages:
   '@types/react@18.3.21':
     resolution: {integrity: sha512-gXLBtmlcRJeT09/sI4PxVwyrku6SaNUj/6cMubjE6T6XdY1fDmBL7r0nX0jbSZPU/Xr0KuwLLZh6aOYY5d91Xw==}
 
+  '@types/semver@7.7.0':
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
   '@typescript-eslint/eslint-plugin@8.32.0':
     resolution: {integrity: sha512-/jU9ettcntkBFmWUzzGgsClEi2ZFiikMX5eEQsmxIAWMOn4H3D4rvHssstmAHGVvrYnaMqdWWWg0b5M6IN/MTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -419,6 +547,10 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/scope-manager@5.62.0':
+    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@typescript-eslint/scope-manager@8.32.0':
     resolution: {integrity: sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -430,9 +562,22 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/types@5.62.0':
+    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@typescript-eslint/types@8.32.0':
     resolution: {integrity: sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@5.62.0':
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@typescript-eslint/typescript-estree@8.32.0':
     resolution: {integrity: sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==}
@@ -440,12 +585,22 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/utils@5.62.0':
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@typescript-eslint/utils@8.32.0':
     resolution: {integrity: sha512-8S9hXau6nQ/sYVtC3D6ISIDoJzS1NsCK+gluVhLN2YkBPX+/1wkwyUiDKnxRh15579WoOIyVWnoyIf3yGI9REw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@5.62.0':
+    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@typescript-eslint/visitor-keys@8.32.0':
     resolution: {integrity: sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==}
@@ -571,6 +726,12 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  antd@5.25.1:
+    resolution: {integrity: sha512-4KC7KuPCjr0z3Vuw9DsF+ceqJaPLbuUI3lOX1sY8ix25ceamp+P8yxOmk3Y2JHCD2ZAhq+5IQ/DTJRN2adWYKQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   apexcharts@4.7.0:
     resolution: {integrity: sha512-iZSrrBGvVlL+nt2B1NpqfDuBZ9jX61X9I2+XV0hlYXHtTwhwLTHDKGXjNXAgFBDLuvSYCB/rq2nPWVPRv2DrGA==}
 
@@ -588,6 +749,10 @@ packages:
   array-includes@3.1.8:
     resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
     engines: {node: '>= 0.4'}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
@@ -682,6 +847,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -696,11 +864,17 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  compute-scroll-into-view@3.1.1:
+    resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  copy-to-clipboard@3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -727,6 +901,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -759,6 +936,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -908,11 +1089,20 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
+  eslint-plugin-react-refresh@0.4.20:
+    resolution: {integrity: sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==}
+    peerDependencies:
+      eslint: '>=8.40'
+
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -942,6 +1132,10 @@ packages:
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
@@ -1078,6 +1272,10 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1289,6 +1487,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json2mq@0.2.0:
+    resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -1524,6 +1725,234 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  rc-cascader@3.34.0:
+    resolution: {integrity: sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-checkbox@3.5.0:
+    resolution: {integrity: sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-collapse@3.9.0:
+    resolution: {integrity: sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-dialog@9.6.0:
+    resolution: {integrity: sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-drawer@7.2.0:
+    resolution: {integrity: sha512-9lOQ7kBekEJRdEpScHvtmEtXnAsy+NGDXiRWc2ZVC7QXAazNVbeT4EraQKYwCME8BJLa8Bxqxvs5swwyOepRwg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-dropdown@4.2.1:
+    resolution: {integrity: sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==}
+    peerDependencies:
+      react: '>=16.11.0'
+      react-dom: '>=16.11.0'
+
+  rc-field-form@2.7.0:
+    resolution: {integrity: sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-image@7.12.0:
+    resolution: {integrity: sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-input-number@9.5.0:
+    resolution: {integrity: sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-input@1.8.0:
+    resolution: {integrity: sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  rc-mentions@2.20.0:
+    resolution: {integrity: sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-menu@9.16.1:
+    resolution: {integrity: sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-motion@2.9.5:
+    resolution: {integrity: sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-notification@5.6.4:
+    resolution: {integrity: sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-overflow@1.4.1:
+    resolution: {integrity: sha512-3MoPQQPV1uKyOMVNd6SZfONi+f3st0r8PksexIdBTeIYbMX0Jr+k7pHEDvsXtR4BpCv90/Pv2MovVNhktKrwvw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-pagination@5.1.0:
+    resolution: {integrity: sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-picker@4.11.3:
+    resolution: {integrity: sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      date-fns: '>= 2.x'
+      dayjs: '>= 1.x'
+      luxon: '>= 3.x'
+      moment: '>= 2.x'
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      date-fns:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+
+  rc-progress@4.0.0:
+    resolution: {integrity: sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-rate@2.13.1:
+    resolution: {integrity: sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-resize-observer@1.4.3:
+    resolution: {integrity: sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-segmented@2.7.0:
+    resolution: {integrity: sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  rc-select@14.16.7:
+    resolution: {integrity: sha512-lT9kO5gFHQdJzu9a0btcOtNaJHkhenSl8H5mcpgXN9VIMXP59rnkpbdHmPrteixWs1D5zFOTyoTYX3b7joADIQ==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  rc-slider@11.1.8:
+    resolution: {integrity: sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-steps@6.0.1:
+    resolution: {integrity: sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-switch@4.1.0:
+    resolution: {integrity: sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-table@7.50.4:
+    resolution: {integrity: sha512-Y+YuncnQqoS5e7yHvfvlv8BmCvwDYDX/2VixTBEhkMDk9itS9aBINp4nhzXFKiBP/frG4w0pS9d9Rgisl0T1Bw==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-tabs@15.6.1:
+    resolution: {integrity: sha512-/HzDV1VqOsUWyuC0c6AkxVYFjvx9+rFPKZ32ejxX0Uc7QCzcEjTA9/xMgv4HemPKwzBNX8KhGVbbumDjnj92aA==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-textarea@1.10.0:
+    resolution: {integrity: sha512-ai9IkanNuyBS4x6sOL8qu/Ld40e6cEs6pgk93R+XLYg0mDSjNBGey6/ZpDs5+gNLD7urQ14po3V6Ck2dJLt9SA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-tooltip@6.4.0:
+    resolution: {integrity: sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-tree-select@5.27.0:
+    resolution: {integrity: sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  rc-tree@5.13.1:
+    resolution: {integrity: sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==}
+    engines: {node: '>=10.x'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  rc-upload@4.9.0:
+    resolution: {integrity: sha512-pAzlPnyiFn1GCtEybEG2m9nXNzQyWXqWV2xFYCmDxjN9HzyjS5Pz2F+pbNdYw8mMJsixLEKLG0wVy9vOGxJMJA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-util@5.44.4:
+    resolution: {integrity: sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-virtual-list@3.18.6:
+    resolution: {integrity: sha512-TQ5SsutL3McvWmmxqQtMIbfeoE3dGjJrRSfKekgby7WQMpPIFvv4ghytp5Z0s3D8Nik9i9YNOCqHBfk86AwgAA==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   react-apexcharts@1.7.0:
     resolution: {integrity: sha512-03oScKJyNLRf0Oe+ihJxFZliBQM9vW3UWwomVn4YVRTN1jsIR58dLWt0v1sb8RwJVHDMbeHiKQueM0KGpn7nOA==}
     peerDependencies:
@@ -1544,6 +1973,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -1555,6 +1987,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  resize-observer-polyfill@1.5.1:
+    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1598,6 +2033,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scroll-into-view-if-needed@3.1.0:
+    resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1648,6 +2086,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1662,6 +2104,9 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  string-convert@0.2.1:
+    resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1726,6 +2171,9 @@ packages:
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1741,6 +2189,10 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  throttle-debounce@5.0.2:
+    resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
+    engines: {node: '>=12.22'}
+
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
@@ -1748,6 +2200,9 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toggle-selection@1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1758,8 +2213,17 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsutils@3.21.0:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1870,6 +2334,55 @@ packages:
 
 snapshots:
 
+  '@ant-design/colors@7.2.0':
+    dependencies:
+      '@ant-design/fast-color': 2.0.6
+
+  '@ant-design/cssinjs-utils@1.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ant-design/cssinjs': 1.23.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.27.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@ant-design/cssinjs@1.23.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@emotion/hash': 0.8.0
+      '@emotion/unitless': 0.7.5
+      classnames: 2.5.1
+      csstype: 3.1.3
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      stylis: 4.3.6
+
+  '@ant-design/fast-color@2.0.6':
+    dependencies:
+      '@babel/runtime': 7.27.1
+
+  '@ant-design/icons-svg@4.4.2': {}
+
+  '@ant-design/icons@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ant-design/colors': 7.2.0
+      '@ant-design/icons-svg': 4.4.2
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@ant-design/react-slick@1.1.2(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      json2mq: 0.2.0
+      react: 18.3.1
+      resize-observer-polyfill: 1.5.1
+      throttle-debounce: 5.0.2
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -1964,6 +2477,26 @@ snapshots:
       '@emotion/weak-memoize': 0.4.0
       stylis: 4.2.0
 
+  '@emotion/css@11.13.5':
+    dependencies:
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/eslint-plugin@11.12.0(eslint@8.57.1)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@emotion/hash@0.8.0': {}
+
   '@emotion/hash@0.9.2': {}
 
   '@emotion/is-prop-valid@1.3.1':
@@ -2014,6 +2547,8 @@ snapshots:
       - supports-color
 
   '@emotion/unitless@0.10.0': {}
+
+  '@emotion/unitless@0.7.5': {}
 
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.3.1)':
     dependencies:
@@ -2148,6 +2683,75 @@ snapshots:
 
   '@pkgr/core@0.2.4': {}
 
+  '@rc-component/async-validator@5.0.4':
+    dependencies:
+      '@babel/runtime': 7.27.1
+
+  '@rc-component/color-picker@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ant-design/fast-color': 2.0.6
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@rc-component/context@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@rc-component/mini-decimal@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.27.1
+
+  '@rc-component/mutate-observer@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@rc-component/portal@1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@rc-component/qrcode@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@rc-component/tour@1.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/portal': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@rc-component/trigger@2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/portal': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.11.0': {}
@@ -2180,17 +2784,19 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
-  '@tanstack/query-core@5.75.5': {}
+  '@tanstack/query-core@5.75.7': {}
 
-  '@tanstack/react-query@5.75.5(react@18.3.1)':
+  '@tanstack/react-query@5.75.7(react@18.3.1)':
     dependencies:
-      '@tanstack/query-core': 5.75.5
+      '@tanstack/query-core': 5.75.7
       react: 18.3.1
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
@@ -2210,6 +2816,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.14
       csstype: 3.1.3
+
+  '@types/semver@7.7.0': {}
 
   '@typescript-eslint/eslint-plugin@8.32.0(@typescript-eslint/parser@8.32.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
@@ -2240,6 +2848,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/scope-manager@5.62.0':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+
   '@typescript-eslint/scope-manager@8.32.0':
     dependencies:
       '@typescript-eslint/types': 8.32.0
@@ -2256,7 +2869,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/types@5.62.0': {}
+
   '@typescript-eslint/types@8.32.0': {}
+
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.4.0
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.1
+      tsutils: 3.21.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/typescript-estree@8.32.0(typescript@5.8.3)':
     dependencies:
@@ -2272,6 +2901,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.0
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      eslint: 8.57.1
+      eslint-scope: 5.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@8.32.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
@@ -2282,6 +2926,11 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/visitor-keys@5.62.0':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.3
 
   '@typescript-eslint/visitor-keys@8.32.0':
     dependencies:
@@ -2368,6 +3017,64 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  antd@5.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@ant-design/colors': 7.2.0
+      '@ant-design/cssinjs': 1.23.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ant-design/cssinjs-utils': 1.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ant-design/fast-color': 2.0.6
+      '@ant-design/icons': 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ant-design/react-slick': 1.1.2(react@18.3.1)
+      '@babel/runtime': 7.27.1
+      '@rc-component/color-picker': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rc-component/mutate-observer': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rc-component/qrcode': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rc-component/tour': 1.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      copy-to-clipboard: 3.3.3
+      dayjs: 1.11.13
+      rc-cascader: 3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-checkbox: 3.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-collapse: 3.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-dialog: 9.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-drawer: 7.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-dropdown: 4.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-field-form: 2.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-image: 7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-input: 1.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-input-number: 9.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-mentions: 2.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-menu: 9.16.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-notification: 5.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-pagination: 5.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-picker: 4.11.3(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-progress: 4.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-rate: 2.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-segmented: 2.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-select: 14.16.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-slider: 11.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-steps: 6.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-switch: 4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-table: 7.50.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-tabs: 15.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-textarea: 1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-tooltip: 6.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-tree: 5.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-tree-select: 5.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-upload: 4.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      scroll-into-view-if-needed: 3.1.0
+      throttle-debounce: 5.0.2
+    transitivePeerDependencies:
+      - date-fns
+      - luxon
+      - moment
+
   apexcharts@4.7.0:
     dependencies:
       '@svgdotjs/svg.draggable.js': 3.0.6(@svgdotjs/svg.js@3.2.4)
@@ -2394,6 +3101,8 @@ snapshots:
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
       is-string: 1.1.1
+
+  array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -2519,6 +3228,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  classnames@2.5.1: {}
+
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
@@ -2531,9 +3242,15 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  compute-scroll-into-view@3.1.1: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
+
+  copy-to-clipboard@3.3.3:
+    dependencies:
+      toggle-selection: 1.0.6
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -2571,6 +3288,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.13: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -2594,6 +3313,10 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   doctrine@2.1.0:
     dependencies:
@@ -2838,6 +3561,10 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
+  eslint-plugin-react-refresh@0.4.20(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
@@ -2859,6 +3586,11 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
 
   eslint-scope@7.2.2:
     dependencies:
@@ -2925,6 +3657,8 @@ snapshots:
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
 
@@ -3073,6 +3807,15 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   gopd@1.2.0: {}
 
@@ -3277,6 +4020,10 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json2mq@0.2.0:
+    dependencies:
+      string-convert: 0.2.1
 
   json5@1.0.2:
     dependencies:
@@ -3507,6 +4254,325 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-select: 14.16.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-tree: 5.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-checkbox@3.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-collapse@3.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-dialog@9.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/portal': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-drawer@7.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/portal': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-dropdown@4.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-field-form@2.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/async-validator': 5.0.4
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-image@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/portal': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-dialog: 9.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-input-number@9.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/mini-decimal': 1.1.0
+      classnames: 2.5.1
+      rc-input: 1.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-input@1.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-mentions@2.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-input: 1.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-menu: 9.16.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-textarea: 1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-menu@9.16.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-overflow: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-motion@2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-notification@5.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-overflow@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-pagination@5.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-picker@4.11.3(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-overflow: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      dayjs: 1.11.13
+
+  rc-progress@4.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-rate@2.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-resize-observer@1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      resize-observer-polyfill: 1.5.1
+
+  rc-segmented@2.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-select@14.16.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-overflow: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-virtual-list: 3.18.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-slider@11.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-steps@6.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-switch@4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-table@7.50.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/context': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-virtual-list: 3.18.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-tabs@15.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-dropdown: 4.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-menu: 9.16.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-textarea@1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-input: 1.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-tooltip@6.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@rc-component/trigger': 2.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-tree-select@5.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-select: 14.16.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-tree: 5.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-tree@5.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-motion: 2.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-virtual-list: 3.18.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-upload@4.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  rc-util@5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+
+  rc-virtual-list@3.18.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      classnames: 2.5.1
+      rc-resize-observer: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react-apexcharts@1.7.0(apexcharts@4.7.0)(react@18.3.1):
     dependencies:
       apexcharts: 4.7.0
@@ -3524,6 +4590,8 @@ snapshots:
       react: 18.3.1
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react@18.3.1:
     dependencies:
@@ -3548,6 +4616,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -3597,6 +4667,10 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scroll-into-view-if-needed@3.1.0:
+    dependencies:
+      compute-scroll-into-view: 3.1.1
 
   semver@6.3.1: {}
 
@@ -3660,6 +4734,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  slash@3.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.5.7: {}
@@ -3667,6 +4743,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   streamsearch@1.1.0: {}
+
+  string-convert@0.2.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3749,6 +4827,8 @@ snapshots:
 
   stylis@4.2.0: {}
 
+  stylis@4.3.6: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3762,6 +4842,8 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  throttle-debounce@5.0.2: {}
+
   tinyglobby@0.2.13:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
@@ -3770,6 +4852,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toggle-selection@1.0.6: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -3782,7 +4866,14 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
+
+  tsutils@3.21.0(typescript@5.8.3):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.8.3
 
   type-check@0.4.0:
     dependencies:

--- a/src/app/admin/customer-management/page.style.ts
+++ b/src/app/admin/customer-management/page.style.ts
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+export const PageContainer = styled.div`
+    padding: 30px;
+    width: 100%;
+`;
+
+export const ContentColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+`;
+
+export const FilterRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const FilterLabel = styled.p`
+    margin: 0;
+    font-size: 1rem;
+    color: #3c3c3c;
+    min-width: fit-content;
+`;

--- a/src/app/admin/customer-management/page.style.ts
+++ b/src/app/admin/customer-management/page.style.ts
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled';
 
 export const PageContainer = styled.div`
-    padding: 30px;
-    width: 100%;
+  padding: 30px;
+  width: 100%;
 `;
 
 export const ContentColumn = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 `;
 
 export const FilterRow = styled.div`
@@ -18,8 +18,8 @@ export const FilterRow = styled.div`
 `;
 
 export const FilterLabel = styled.p`
-    margin: 0;
-    font-size: 1rem;
-    color: #3c3c3c;
-    min-width: fit-content;
+  margin: 0;
+  font-size: 1rem;
+  color: #3c3c3c;
+  min-width: fit-content;
 `;

--- a/src/app/admin/customer-management/page.tsx
+++ b/src/app/admin/customer-management/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useFilterStore } from '@/stores/filterStore';
+import { useCustomersQuery } from '@/hooks/useCustomersQuery';
+import Conditionbar from '@/components/admin/conditionbar/Conditionbar';
+import DataTable from '@/components/admin/dataTable/DataTable';
+import { Input, InputNumber, Select, Space, Button, DatePicker } from 'antd';
+import dayjs from 'dayjs';
+import {
+  PageContainer,
+  ContentColumn,
+  FilterRow,
+  FilterLabel,
+} from './page.style';
+
+const CustomerManagementPage: React.FC = () => {
+  const { RangePicker } = DatePicker;
+  const {
+    name, setName,
+    gender, setGender,
+    birthRange, setBirthRange,
+    userStatus, setUserStatus,
+    joinDateRange, setJoinDateRange,
+    loanStatus, setLoanStatus,
+    transactionCountMin, setTransactionCountMin,
+    transactionCountMax, setTransactionCountMax,
+  } = useFilterStore();
+
+  // 입력용 임시 필터
+  const [tempFilters, setTempFilters] = useState({
+    name,
+    gender,
+    birthRange,
+    userStatus,
+    joinDateRange,
+    loanStatus,
+    transactionCountMin,
+    transactionCountMax,
+  });
+
+  // 실제 필터
+  const filters = { name, gender, birthRange, userStatus, joinDateRange, loanStatus, transactionCountMin, transactionCountMax };
+  const { data, isLoading } = useCustomersQuery(filters, true);
+
+  // 임시 필터 변경 핸들러
+  const handleTempFilterChange = (key: string, value: any) => {
+    setTempFilters((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  // 조회 버튼 클릭 핸들러
+  const handleSearchClick = () => {
+    setName(tempFilters.name);
+    setGender(tempFilters.gender);
+    setBirthRange(tempFilters.birthRange);
+    setUserStatus(tempFilters.userStatus);
+    setJoinDateRange(tempFilters.joinDateRange);
+    setLoanStatus(tempFilters.loanStatus);
+    setTransactionCountMin(tempFilters.transactionCountMin);
+    setTransactionCountMax(tempFilters.transactionCountMax);
+  };
+
+  return (
+    <PageContainer>
+      <ContentColumn>
+        <Conditionbar title="고객 관리" totalElements="72명">
+          <Space wrap size='middle'>
+            <FilterRow>
+              <FilterLabel>이름</FilterLabel>
+              <Input
+                placeholder="이름"
+                value={tempFilters.name}
+                onChange={e => handleTempFilterChange('name', e.target.value)}
+                style={{ width: '130px' }}
+              />
+            </FilterRow>
+
+            <FilterRow>
+              <FilterLabel>성별</FilterLabel>
+              <Select
+                value={tempFilters.gender}
+                onChange={e => handleTempFilterChange('gender', e)}
+                options={[
+                  { value: 'all', label: '모두' },
+                  { value: 'female', label: '여성' },
+                  { value: 'male', label: '남성' }
+                ]}
+                style={{ width: 80 }}
+              />
+            </FilterRow>
+
+            <FilterRow>
+              <FilterLabel>생년월일</FilterLabel>
+              <RangePicker
+                format="YYYY-MM-DD"
+                value={
+                  tempFilters.birthRange && tempFilters.birthRange[0] && tempFilters.birthRange[1]
+                    ? [dayjs(tempFilters.birthRange[0]), dayjs(tempFilters.birthRange[1])]
+                    : null
+                }
+                onChange={(_, dateStrings: [string, string]) =>
+                  handleTempFilterChange('birthRange', dateStrings)
+                }
+                style={{ width: '240px' }}
+              />
+            </FilterRow>
+
+            <FilterRow>
+              <FilterLabel>사용자 상태</FilterLabel>
+              <Select
+                value={tempFilters.userStatus}
+                onChange={value => handleTempFilterChange('userStatus', value)}
+                options={[
+                  { value: 'all', label: '모두' },
+                  { value: 'active', label: '활성' },
+                  { value: 'inactive', label: '비활성' }
+                ]}
+                style={{ width: 100 }}
+              />
+            </FilterRow>
+
+            <FilterRow>
+              <FilterLabel>가입일</FilterLabel>
+              <RangePicker
+                format="YYYY-MM-DD"
+                value={
+                  tempFilters.joinDateRange && tempFilters.joinDateRange[0] && tempFilters.joinDateRange[1]
+                    ? [dayjs(tempFilters.joinDateRange[0]), dayjs(tempFilters.joinDateRange[1])]
+                    : null
+                }
+                onChange={(_, dateStrings: [string, string]) =>
+                  handleTempFilterChange('joinDateRange', dateStrings)
+                }
+                style={{ width: '240px' }}
+              />
+            </FilterRow>
+
+            <FilterRow>
+              <FilterLabel>대출중 여부</FilterLabel>
+              <Select
+                value={tempFilters.loanStatus}
+                onChange={value => handleTempFilterChange('loanStatus', value)}
+                options={[
+                  { value: 'all', label: '모두' },
+                  { value: 'true', label: '대출중' },
+                  { value: 'false', label: '대출중 아님' }
+                ]}
+                style={{ width: 120 }}
+              />
+            </FilterRow>
+
+            <FilterRow>
+              <FilterLabel>거래내역 횟수</FilterLabel>
+              <InputNumber
+                min={0}
+                max={100}
+                value={tempFilters.transactionCountMin}
+                onChange={value => handleTempFilterChange('transactionCountMin', value)}
+                style={{ width: '65px' }}
+              />
+              <p>~</p>
+              <InputNumber
+                min={0}
+                max={100}
+                value={tempFilters.transactionCountMax}
+                onChange={value => handleTempFilterChange('transactionCountMax', value)}
+                style={{ width: '65px' }}
+              />
+            </FilterRow>
+          </Space>
+
+          <Button type="primary" onClick={handleSearchClick}>
+            조회
+          </Button>
+        </Conditionbar>
+
+        <DataTable data={data?.list ?? []} loading={isLoading} />
+      </ContentColumn>
+    </PageContainer>
+  );
+}
+
+export default CustomerManagementPage;

--- a/src/app/admin/customer-management/page.tsx
+++ b/src/app/admin/customer-management/page.tsx
@@ -1,34 +1,46 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useFilterStore } from '@/stores/filterStore';
-import { useCustomersQuery } from '@/hooks/useCustomersQuery';
-import Conditionbar from '@/components/admin/conditionbar/Conditionbar';
-import DataTable from '@/components/admin/dataTable/DataTable';
+
 import { Input, InputNumber, Select, Space, Button, DatePicker } from 'antd';
 import dayjs from 'dayjs';
-import {
-  PageContainer,
-  ContentColumn,
-  FilterRow,
-  FilterLabel,
-} from './page.style';
 
-const CustomerManagementPage: React.FC = () => {
+import Conditionbar from '@/components/admin/conditionbar/Conditionbar';
+import DataTable from '@/components/admin/dataTable/DataTable';
+import { useCustomersQuery } from '@/hooks/useCustomersQuery';
+import { useFilterStore } from '@/stores/filterStore';
+import type { FilterType } from '@/types/filter.type';
+
+import { PageContainer, ContentColumn, FilterRow, FilterLabel } from './page.style';
+
+/**
+ * 관리자 페이지 - 고객 관리 메뉴
+ * @since 2025.05.12
+ * @author 권민지
+ */
+const CustomerManagementPage = () => {
   const { RangePicker } = DatePicker;
   const {
-    name, setName,
-    gender, setGender,
-    birthRange, setBirthRange,
-    userStatus, setUserStatus,
-    joinDateRange, setJoinDateRange,
-    loanStatus, setLoanStatus,
-    transactionCountMin, setTransactionCountMin,
-    transactionCountMax, setTransactionCountMax,
+    name,
+    setName,
+    gender,
+    setGender,
+    birthRange,
+    setBirthRange,
+    userStatus,
+    setUserStatus,
+    joinDateRange,
+    setJoinDateRange,
+    loanStatus,
+    setLoanStatus,
+    transactionCountMin,
+    setTransactionCountMin,
+    transactionCountMax,
+    setTransactionCountMax,
   } = useFilterStore();
 
   // 입력용 임시 필터
-  const [tempFilters, setTempFilters] = useState({
+  const [tempFilters, setTempFilters] = useState<FilterType>({
     name,
     gender,
     birthRange,
@@ -40,11 +52,20 @@ const CustomerManagementPage: React.FC = () => {
   });
 
   // 실제 필터
-  const filters = { name, gender, birthRange, userStatus, joinDateRange, loanStatus, transactionCountMin, transactionCountMax };
-  const { data, isLoading } = useCustomersQuery(filters, true);
+  const filters = {
+    name,
+    gender,
+    birthRange,
+    userStatus,
+    joinDateRange,
+    loanStatus,
+    transactionCountMin,
+    transactionCountMax,
+  };
+  const { data, isLoading } = useCustomersQuery(filters);
 
   // 임시 필터 변경 핸들러
-  const handleTempFilterChange = (key: string, value: any) => {
+  const handleTempFilterChange = <K extends keyof FilterType>(key: K, value: FilterType[K]) => {
     setTempFilters((prev) => ({
       ...prev,
       [key]: value,
@@ -67,13 +88,13 @@ const CustomerManagementPage: React.FC = () => {
     <PageContainer>
       <ContentColumn>
         <Conditionbar title="고객 관리" totalElements="72명">
-          <Space wrap size='middle'>
+          <Space wrap size="middle">
             <FilterRow>
               <FilterLabel>이름</FilterLabel>
               <Input
                 placeholder="이름"
                 value={tempFilters.name}
-                onChange={e => handleTempFilterChange('name', e.target.value)}
+                onChange={(e) => handleTempFilterChange('name', e.target.value)}
                 style={{ width: '130px' }}
               />
             </FilterRow>
@@ -82,11 +103,11 @@ const CustomerManagementPage: React.FC = () => {
               <FilterLabel>성별</FilterLabel>
               <Select
                 value={tempFilters.gender}
-                onChange={e => handleTempFilterChange('gender', e)}
+                onChange={(e) => handleTempFilterChange('gender', e)}
                 options={[
                   { value: 'all', label: '모두' },
                   { value: 'female', label: '여성' },
-                  { value: 'male', label: '남성' }
+                  { value: 'male', label: '남성' },
                 ]}
                 style={{ width: 80 }}
               />
@@ -112,11 +133,11 @@ const CustomerManagementPage: React.FC = () => {
               <FilterLabel>사용자 상태</FilterLabel>
               <Select
                 value={tempFilters.userStatus}
-                onChange={value => handleTempFilterChange('userStatus', value)}
+                onChange={(value) => handleTempFilterChange('userStatus', value)}
                 options={[
                   { value: 'all', label: '모두' },
                   { value: 'active', label: '활성' },
-                  { value: 'inactive', label: '비활성' }
+                  { value: 'inactive', label: '비활성' },
                 ]}
                 style={{ width: 100 }}
               />
@@ -127,7 +148,9 @@ const CustomerManagementPage: React.FC = () => {
               <RangePicker
                 format="YYYY-MM-DD"
                 value={
-                  tempFilters.joinDateRange && tempFilters.joinDateRange[0] && tempFilters.joinDateRange[1]
+                  tempFilters.joinDateRange &&
+                  tempFilters.joinDateRange[0] &&
+                  tempFilters.joinDateRange[1]
                     ? [dayjs(tempFilters.joinDateRange[0]), dayjs(tempFilters.joinDateRange[1])]
                     : null
                 }
@@ -142,11 +165,11 @@ const CustomerManagementPage: React.FC = () => {
               <FilterLabel>대출중 여부</FilterLabel>
               <Select
                 value={tempFilters.loanStatus}
-                onChange={value => handleTempFilterChange('loanStatus', value)}
+                onChange={(value) => handleTempFilterChange('loanStatus', value)}
                 options={[
                   { value: 'all', label: '모두' },
                   { value: 'true', label: '대출중' },
-                  { value: 'false', label: '대출중 아님' }
+                  { value: 'false', label: '대출중 아님' },
                 ]}
                 style={{ width: 120 }}
               />
@@ -158,7 +181,7 @@ const CustomerManagementPage: React.FC = () => {
                 min={0}
                 max={100}
                 value={tempFilters.transactionCountMin}
-                onChange={value => handleTempFilterChange('transactionCountMin', value)}
+                onChange={(value) => handleTempFilterChange('transactionCountMin', value)}
                 style={{ width: '65px' }}
               />
               <p>~</p>
@@ -166,7 +189,7 @@ const CustomerManagementPage: React.FC = () => {
                 min={0}
                 max={100}
                 value={tempFilters.transactionCountMax}
-                onChange={value => handleTempFilterChange('transactionCountMax', value)}
+                onChange={(value) => handleTempFilterChange('transactionCountMax', value)}
                 style={{ width: '65px' }}
               />
             </FilterRow>
@@ -181,6 +204,6 @@ const CustomerManagementPage: React.FC = () => {
       </ContentColumn>
     </PageContainer>
   );
-}
+};
 
 export default CustomerManagementPage;

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,15 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 import AdminLayout from '@/components/admin/AdminLayout/AdminLayout';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <AdminLayout>{children}</AdminLayout>;
+  const [queryClient] = React.useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AdminLayout>{children}</AdminLayout>
+    </QueryClientProvider>
+  );
 }

--- a/src/components/admin/Sidebar/Sidebar.style.ts
+++ b/src/components/admin/Sidebar/Sidebar.style.ts
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 export const SidebarWrapper = styled.aside`
   width: 250px;
-  height: 100vh;
+  min-height: calc(100vh - 73px);
   background-color: #f9fafc;
   padding: 24px 16px;
   border-right: 1px solid #d9d9d9;

--- a/src/components/admin/conditionbar/Conditionbar.style.ts
+++ b/src/components/admin/conditionbar/Conditionbar.style.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const ConditionbarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const TitleRow = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-end;
+  gap: 0.5rem;
+`;
+
+export const Title = styled.h2`
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+`;
+
+export const Total = styled.span`
+  color: #262626;
+  font-size: 1.1rem;
+`;
+
+export const ConditionBox = styled.div`
+  width: 100%;
+  padding: 20px 30px;
+  border: 1px solid #D9D9D9;
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  background: #fff;
+`;

--- a/src/components/admin/conditionbar/Conditionbar.tsx
+++ b/src/components/admin/conditionbar/Conditionbar.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import {
-  ConditionbarWrapper,
-  TitleRow,
-  Title,
-  Total,
-  ConditionBox
-} from './Conditionbar.style';
+
+import { ConditionbarWrapper, TitleRow, Title, Total, ConditionBox } from './Conditionbar.style';
 
 interface ConditionbarProps {
   title: string;
@@ -13,18 +8,16 @@ interface ConditionbarProps {
   children: React.ReactNode;
 }
 
-const Conditionbar: React.FC<ConditionbarProps> = ({ title, totalElements, children}) => {
+const Conditionbar = ({ title, totalElements, children }: ConditionbarProps) => {
   return (
     <ConditionbarWrapper>
       <TitleRow>
         <Title>{title}</Title>
         {totalElements && <Total>{totalElements}</Total>}
       </TitleRow>
-      <ConditionBox>
-        {children}
-      </ConditionBox>
+      <ConditionBox>{children}</ConditionBox>
     </ConditionbarWrapper>
   );
-}
+};
 
 export default Conditionbar;

--- a/src/components/admin/conditionbar/Conditionbar.tsx
+++ b/src/components/admin/conditionbar/Conditionbar.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+  ConditionbarWrapper,
+  TitleRow,
+  Title,
+  Total,
+  ConditionBox
+} from './Conditionbar.style';
+
+interface ConditionbarProps {
+  title: string;
+  totalElements?: string;
+  children: React.ReactNode;
+}
+
+const Conditionbar: React.FC<ConditionbarProps> = ({ title, totalElements, children}) => {
+  return (
+    <ConditionbarWrapper>
+      <TitleRow>
+        <Title>{title}</Title>
+        {totalElements && <Total>{totalElements}</Total>}
+      </TitleRow>
+      <ConditionBox>
+        {children}
+      </ConditionBox>
+    </ConditionbarWrapper>
+  );
+}
+
+export default Conditionbar;

--- a/src/components/admin/dataTable/DataTable.style.ts
+++ b/src/components/admin/dataTable/DataTable.style.ts
@@ -11,7 +11,7 @@ export const TableWrapper = styled.div`
 `;
 
 export const TableTitleWrapper = styled.div`
-    text-align: 'center';
+    text-align: center;
 `;
 
 export const PaginationCenterWrapper = styled.div`

--- a/src/components/admin/dataTable/DataTable.style.ts
+++ b/src/components/admin/dataTable/DataTable.style.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const TableWrapper = styled.div`
+    border-radius: 8px;
+    border: 1px solid #DBDBDB;
+    overflow: hidden;
+    background: #fff;
+`;
+
+export const TableTitleWrapper = styled.div`
+    text-align: 'center';
+`;
+
+export const PaginationCenterWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    margin-top: 24px;
+`;
+
+export const EmptyTextWrapper = styled.div`
+    text-align: center;
+    min-height: 408px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+export const rowCellStyle = css`
+    height: 54px;
+    min-height: 54px;
+    max-height: 54px;
+    padding-top: 0;
+    padding-bottom: 0;
+    vertical-align: middle;
+`;
+
+export const emptyRowStyle = css`
+    & .ant-table-cell {
+        border: none !important;
+        background: transparent !important;
+        pointer-events: none;
+    }
+`;
+
+export const customRowHoverStyle = css`
+    &:hover > .ant-table-cell {
+        background: #008EFF0F !important;
+    }
+`;
+
+export const lastRowNoBorderStyle = css`
+  & > .ant-table-cell {
+    border-bottom: none !important;
+  }
+`;

--- a/src/components/admin/dataTable/DataTable.style.ts
+++ b/src/components/admin/dataTable/DataTable.style.ts
@@ -4,51 +4,51 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const TableWrapper = styled.div`
-    border-radius: 8px;
-    border: 1px solid #DBDBDB;
-    overflow: hidden;
-    background: #fff;
+  border-radius: 8px;
+  border: 1px solid #dbdbdb;
+  overflow: hidden;
+  background: #fff;
 `;
 
 export const TableTitleWrapper = styled.div`
-    text-align: center;
+  text-align: center;
 `;
 
 export const PaginationCenterWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-    margin-top: 24px;
+  display: flex;
+  justify-content: center;
+  margin-top: 24px;
 `;
 
 export const EmptyTextWrapper = styled.div`
-    text-align: center;
-    min-height: 408px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  text-align: center;
+  min-height: 408px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const rowCellStyle = css`
-    height: 54px;
-    min-height: 54px;
-    max-height: 54px;
-    padding-top: 0;
-    padding-bottom: 0;
-    vertical-align: middle;
+  height: 54px;
+  min-height: 54px;
+  max-height: 54px;
+  padding-top: 0;
+  padding-bottom: 0;
+  vertical-align: middle;
 `;
 
 export const emptyRowStyle = css`
-    & .ant-table-cell {
-        border: none !important;
-        background: transparent !important;
-        pointer-events: none;
-    }
+  & .ant-table-cell {
+    border: none !important;
+    background: transparent !important;
+    pointer-events: none;
+  }
 `;
 
 export const customRowHoverStyle = css`
-    &:hover > .ant-table-cell {
-        background: #008EFF0F !important;
-    }
+  &:hover > .ant-table-cell {
+    background: #008eff0f !important;
+  }
 `;
 
 export const lastRowNoBorderStyle = css`

--- a/src/components/admin/dataTable/DataTable.tsx
+++ b/src/components/admin/dataTable/DataTable.tsx
@@ -252,7 +252,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
       birth: '',
       status: '',
       joinDate: '',
-      loanCount: '',
+      loanCount: 0,
       loanStatus: '',
       isEmpty: true,
     }));

--- a/src/components/admin/dataTable/DataTable.tsx
+++ b/src/components/admin/dataTable/DataTable.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
-import { Table, Pagination } from 'antd';
+
 import { css, cx } from '@emotion/css';
+import { Table, Pagination } from 'antd';
+
 import {
   rowCellStyle,
   emptyRowStyle,
@@ -14,7 +16,7 @@ import {
 } from './DataTable.style';
 
 interface DataTableProps {
-  data: any[];
+  data: DataType[];
   loading: boolean;
 }
 
@@ -234,7 +236,7 @@ const sampleData: DataType[] = [
 
 const PAGE_SIZE = 8;
 
-const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
+const DataTable = ({ data, loading }: DataTableProps) => {
   const tableData = data && data.length > 0 ? data : sampleData;
   const [current, setCurrent] = React.useState(1);
   const pagedData = tableData.slice((current - 1) * PAGE_SIZE, current * PAGE_SIZE);
@@ -246,7 +248,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
     const emptyRowsCount = PAGE_SIZE - pagedData.length;
     const emptyRows = Array.from({ length: emptyRowsCount }, (_, idx) => ({
       key: `empty-${idx}`,
-      no: '',
+      no: 0,
       name: '',
       gender: '',
       birth: '',
@@ -291,7 +293,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="no"
             width={COLUMN_WIDTHS.no}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>이름</TableTitleWrapper>}
@@ -299,7 +301,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="name"
             width={COLUMN_WIDTHS.name}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>성별</TableTitleWrapper>}
@@ -307,7 +309,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="gender"
             width={COLUMN_WIDTHS.gender}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>생년월일</TableTitleWrapper>}
@@ -315,7 +317,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="birth"
             width={COLUMN_WIDTHS.birth}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>상태</TableTitleWrapper>}
@@ -323,7 +325,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="status"
             width={COLUMN_WIDTHS.status}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>가입일</TableTitleWrapper>}
@@ -331,7 +333,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="joinDate"
             width={COLUMN_WIDTHS.joinDate}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>대출 횟수</TableTitleWrapper>}
@@ -339,7 +341,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="loanCount"
             width={COLUMN_WIDTHS.loanCount}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
           <Table.Column
             title={<TableTitleWrapper>대출 중 여부</TableTitleWrapper>}
@@ -347,7 +349,7 @@ const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
             key="loanStatus"
             width={COLUMN_WIDTHS.loanStatus}
             align="center"
-            render={(text, record: any) => record.isEmpty ? null : text}
+            render={(text, record: DataType) => (record.isEmpty ? null : text)}
           />
         </Table>
       </TableWrapper>

--- a/src/components/admin/dataTable/DataTable.tsx
+++ b/src/components/admin/dataTable/DataTable.tsx
@@ -1,0 +1,367 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { Table, Pagination } from 'antd';
+import { css, cx } from '@emotion/css';
+import {
+  rowCellStyle,
+  emptyRowStyle,
+  customRowHoverStyle,
+  lastRowNoBorderStyle,
+  EmptyTextWrapper,
+  TableWrapper,
+  TableTitleWrapper,
+  PaginationCenterWrapper,
+} from './DataTable.style';
+
+interface DataTableProps {
+  data: any[];
+  loading: boolean;
+}
+
+interface DataType {
+  key: React.Key;
+  no: number;
+  name: string;
+  gender: string;
+  birth: string;
+  status: string;
+  joinDate: string;
+  loanCount: number;
+  loanStatus: string;
+  isEmpty?: boolean;
+}
+
+const COLUMN_WIDTHS = {
+  no: 30,
+  name: 100,
+  gender: 80,
+  birth: 120,
+  status: 80,
+  joinDate: 120,
+  loanCount: 100,
+  loanStatus: 140,
+};
+
+const sampleData: DataType[] = [
+  {
+    key: 1,
+    no: 1,
+    name: '김철수',
+    gender: '남성',
+    birth: '1990-01-15',
+    status: '활성',
+    joinDate: '2022-01-01',
+    loanCount: 2,
+    loanStatus: '대출중',
+  },
+  {
+    key: 2,
+    no: 2,
+    name: '이영희',
+    gender: '여성',
+    birth: '1988-05-23',
+    status: '비활성',
+    joinDate: '2021-03-14',
+    loanCount: 0,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 3,
+    no: 3,
+    name: '박민수',
+    gender: '남성',
+    birth: '1992-09-10',
+    status: '활성',
+    joinDate: '2022-07-21',
+    loanCount: 1,
+    loanStatus: '대출중',
+  },
+  {
+    key: 4,
+    no: 4,
+    name: '최지은',
+    gender: '여성',
+    birth: '1995-12-30',
+    status: '활성',
+    joinDate: '2023-02-18',
+    loanCount: 3,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 5,
+    no: 5,
+    name: '정우성',
+    gender: '남성',
+    birth: '1986-04-07',
+    status: '비활성',
+    joinDate: '2020-11-11',
+    loanCount: 0,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 6,
+    no: 6,
+    name: '한가인',
+    gender: '여성',
+    birth: '1993-08-19',
+    status: '활성',
+    joinDate: '2021-06-25',
+    loanCount: 4,
+    loanStatus: '대출중',
+  },
+  {
+    key: 7,
+    no: 7,
+    name: '오세훈',
+    gender: '남성',
+    birth: '1991-10-05',
+    status: '활성',
+    joinDate: '2022-10-30',
+    loanCount: 2,
+    loanStatus: '대출중',
+  },
+  {
+    key: 8,
+    no: 8,
+    name: '서지수',
+    gender: '여성',
+    birth: '1994-02-11',
+    status: '비활성',
+    joinDate: '2020-12-09',
+    loanCount: 1,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 9,
+    no: 9,
+    name: '장동건',
+    gender: '남성',
+    birth: '1987-07-29',
+    status: '활성',
+    joinDate: '2021-05-13',
+    loanCount: 5,
+    loanStatus: '대출중',
+  },
+  {
+    key: 10,
+    no: 10,
+    name: '이수지',
+    gender: '여성',
+    birth: '1996-03-22',
+    status: '비활성',
+    joinDate: '2023-01-05',
+    loanCount: 0,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 11,
+    no: 11,
+    name: '김영희',
+    gender: '여성',
+    birth: '1990-11-13',
+    status: '활성',
+    joinDate: '2022-04-18',
+    loanCount: 1,
+    loanStatus: '대출중',
+  },
+  {
+    key: 12,
+    no: 12,
+    name: '최민수',
+    gender: '남성',
+    birth: '1989-06-17',
+    status: '비활성',
+    joinDate: '2020-09-21',
+    loanCount: 2,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 13,
+    no: 13,
+    name: '박지성',
+    gender: '남성',
+    birth: '1985-12-25',
+    status: '활성',
+    joinDate: '2021-08-15',
+    loanCount: 3,
+    loanStatus: '대출중',
+  },
+  {
+    key: 14,
+    no: 14,
+    name: '손예진',
+    gender: '여성',
+    birth: '1992-02-02',
+    status: '비활성',
+    joinDate: '2022-12-12',
+    loanCount: 0,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 15,
+    no: 15,
+    name: '유재석',
+    gender: '남성',
+    birth: '1988-10-10',
+    status: '활성',
+    joinDate: '2023-03-01',
+    loanCount: 4,
+    loanStatus: '대출중',
+  },
+  {
+    key: 16,
+    no: 16,
+    name: '강호동',
+    gender: '남성',
+    birth: '1987-05-20',
+    status: '비활성',
+    joinDate: '2020-07-07',
+    loanCount: 1,
+    loanStatus: '대출중 아님',
+  },
+  {
+    key: 17,
+    no: 17,
+    name: '장나라',
+    gender: '여성',
+    birth: '1995-11-09',
+    status: '활성',
+    joinDate: '2021-11-30',
+    loanCount: 2,
+    loanStatus: '대출중',
+  },
+];
+
+const PAGE_SIZE = 8;
+
+const DataTable: React.FC<DataTableProps> = ({ data, loading }) => {
+  const tableData = data && data.length > 0 ? data : sampleData;
+  const [current, setCurrent] = React.useState(1);
+  const pagedData = tableData.slice((current - 1) * PAGE_SIZE, current * PAGE_SIZE);
+  let renderData: DataType[];
+
+  if (tableData.length === 0) {
+    renderData = [];
+  } else {
+    const emptyRowsCount = PAGE_SIZE - pagedData.length;
+    const emptyRows = Array.from({ length: emptyRowsCount }, (_, idx) => ({
+      key: `empty-${idx}`,
+      no: '',
+      name: '',
+      gender: '',
+      birth: '',
+      status: '',
+      joinDate: '',
+      loanCount: '',
+      loanStatus: '',
+      isEmpty: true,
+    }));
+    renderData = [...pagedData, ...emptyRows];
+  }
+
+  return (
+    <>
+      <TableWrapper>
+        <Table<DataType>
+          dataSource={renderData}
+          loading={loading}
+          pagination={false}
+          style={{ minHeight: '495px' }}
+          scroll={{ x: 'max-content' }}
+          locale={{
+            emptyText: (
+              <EmptyTextWrapper>
+                <p>조회된 데이터가 없습니다.</p>
+              </EmptyTextWrapper>
+            ),
+          }}
+          rowKey="key"
+          rowClassName={(record, index) =>
+            cx(
+              css(rowCellStyle),
+              css(customRowHoverStyle),
+              record.isEmpty && css(emptyRowStyle),
+              index === renderData.length - 1 && css(lastRowNoBorderStyle)
+            )
+          }
+        >
+          <Table.Column
+            title={<TableTitleWrapper>No</TableTitleWrapper>}
+            dataIndex="no"
+            key="no"
+            width={COLUMN_WIDTHS.no}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>이름</TableTitleWrapper>}
+            dataIndex="name"
+            key="name"
+            width={COLUMN_WIDTHS.name}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>성별</TableTitleWrapper>}
+            dataIndex="gender"
+            key="gender"
+            width={COLUMN_WIDTHS.gender}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>생년월일</TableTitleWrapper>}
+            dataIndex="birth"
+            key="birth"
+            width={COLUMN_WIDTHS.birth}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>상태</TableTitleWrapper>}
+            dataIndex="status"
+            key="status"
+            width={COLUMN_WIDTHS.status}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>가입일</TableTitleWrapper>}
+            dataIndex="joinDate"
+            key="joinDate"
+            width={COLUMN_WIDTHS.joinDate}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>대출 횟수</TableTitleWrapper>}
+            dataIndex="loanCount"
+            key="loanCount"
+            width={COLUMN_WIDTHS.loanCount}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+          <Table.Column
+            title={<TableTitleWrapper>대출 중 여부</TableTitleWrapper>}
+            dataIndex="loanStatus"
+            key="loanStatus"
+            width={COLUMN_WIDTHS.loanStatus}
+            align="center"
+            render={(text, record: any) => record.isEmpty ? null : text}
+          />
+        </Table>
+      </TableWrapper>
+      <PaginationCenterWrapper>
+        <Pagination
+          pageSize={PAGE_SIZE}
+          current={current}
+          total={tableData.length}
+          onChange={setCurrent}
+          showSizeChanger={false}
+        />
+      </PaginationCenterWrapper>
+    </>
+  );
+};
+
+export default DataTable;

--- a/src/hooks/useCustomersQuery.ts
+++ b/src/hooks/useCustomersQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+const fetchCustomers = async (filters: any) => {
+  // 추후 실제 API 요청 추가 예정
+  const params = new URLSearchParams(filters).toString();
+  const res = await fetch(`/api/customers?${params}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+};
+
+export const useCustomersQuery = (filters: any, enabled: boolean) => {
+  return useQuery({
+    queryKey: ['customers', filters],
+    queryFn: () => fetchCustomers(filters),
+    enabled,
+  });
+};

--- a/src/hooks/useCustomersQuery.ts
+++ b/src/hooks/useCustomersQuery.ts
@@ -1,17 +1,46 @@
+import { useMemo } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 
-const fetchCustomers = async (filters: any) => {
+import { FilterType } from '@/types/filter.type';
+
+function useCustomerQueryParams(filters: FilterType) {
+  return useMemo(() => {
+    const params: Record<string, string> = {};
+    if (filters.name) params.name = filters.name;
+    if (filters.gender && filters.gender !== 'ALL') params.gender = filters.gender;
+    if (filters.birthRange && filters.birthRange[0] && filters.birthRange[1]) {
+      params.birthStart = filters.birthRange[0];
+      params.birthEnd = filters.birthRange[1];
+    }
+    if (filters.userStatus && filters.userStatus !== 'ALL') params.userStatus = filters.userStatus;
+    if (filters.joinDateRange && filters.joinDateRange[0] && filters.joinDateRange[1]) {
+      params.joinStart = filters.joinDateRange[0];
+      params.joinEnd = filters.joinDateRange[1];
+    }
+    if (filters.loanStatus && filters.loanStatus !== 'ALL') params.loanStatus = filters.loanStatus;
+    if (filters.transactionCountMin !== null && filters.transactionCountMin !== undefined) {
+      params.transactionCountMin = String(filters.transactionCountMin);
+    }
+    if (filters.transactionCountMax !== null && filters.transactionCountMax !== undefined) {
+      params.transactionCountMax = String(filters.transactionCountMax);
+    }
+    return params;
+  }, [filters]);
+}
+
+const fetchCustomers = async (paramsObj: Record<string, string>) => {
+  const params = new URLSearchParams(paramsObj).toString();
   // 추후 실제 API 요청 추가 예정
-  const params = new URLSearchParams(filters).toString();
   const res = await fetch(`/api/customers?${params}`);
   if (!res.ok) throw new Error('Failed to fetch');
   return res.json();
 };
 
-export const useCustomersQuery = (filters: any, enabled: boolean) => {
+export const useCustomersQuery = (filters: FilterType) => {
+  const params = useCustomerQueryParams(filters);
   return useQuery({
-    queryKey: ['customers', filters],
-    queryFn: () => fetchCustomers(filters),
-    enabled,
+    queryKey: ['customers', params],
+    queryFn: () => fetchCustomers(params),
   });
 };

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -1,33 +1,30 @@
 import { create } from 'zustand';
 
-type FilterState = {
-  name: string;
-  gender: string;
-  birthRange: [string, string] | null;
-  userStatus: string;
-  joinDateRange: [string, string] | null;
-  loanStatus: string;
-  transactionCountMin: number | null;
-  transactionCountMax: number | null;
+import { GenderType, UserStatusType, LoanStatusType, FilterType } from '@/types/filter.type';
+
+/**
+ * 관리자 페이지 필터 정보 타입
+ */
+export interface FilterState extends FilterType {
   setName: (name: string) => void;
-  setGender: (gender: string) => void;
+  setGender: (gender: GenderType) => void;
   setBirthRange: (range: [string, string] | null) => void;
-  setUserStatus: (status: string) => void;
+  setUserStatus: (status: UserStatusType) => void;
   setJoinDateRange: (range: [string, string] | null) => void;
-  setLoanStatus: (status: string) => void;
+  setLoanStatus: (status: LoanStatusType) => void;
   setTransactionCountMin: (min: number | null) => void;
   setTransactionCountMax: (max: number | null) => void;
-};
+}
 
 export const useFilterStore = create<FilterState>((set) => ({
   name: '',
-  gender: 'all',
+  gender: 'ALL',
   birthRange: null,
-  userStatus: 'all',
+  userStatus: 'ALL',
   joinDateRange: null,
-  loanStatus: 'all',
-  transactionCountMin: 0,
-  transactionCountMax: 100,
+  loanStatus: 'ALL',
+  transactionCountMin: null,
+  transactionCountMax: null,
   setName: (name) => set({ name }),
   setGender: (gender) => set({ gender }),
   setBirthRange: (birthRange) => set({ birthRange }),

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+type FilterState = {
+  name: string;
+  gender: string;
+  birthRange: [string, string] | null;
+  userStatus: string;
+  joinDateRange: [string, string] | null;
+  loanStatus: string;
+  transactionCountMin: number | null;
+  transactionCountMax: number | null;
+  setName: (name: string) => void;
+  setGender: (gender: string) => void;
+  setBirthRange: (range: [string, string] | null) => void;
+  setUserStatus: (status: string) => void;
+  setJoinDateRange: (range: [string, string] | null) => void;
+  setLoanStatus: (status: string) => void;
+  setTransactionCountMin: (min: number | null) => void;
+  setTransactionCountMax: (max: number | null) => void;
+};
+
+export const useFilterStore = create<FilterState>((set) => ({
+  name: '',
+  gender: 'all',
+  birthRange: null,
+  userStatus: 'all',
+  joinDateRange: null,
+  loanStatus: 'all',
+  transactionCountMin: 0,
+  transactionCountMax: 100,
+  setName: (name) => set({ name }),
+  setGender: (gender) => set({ gender }),
+  setBirthRange: (birthRange) => set({ birthRange }),
+  setUserStatus: (userStatus) => set({ userStatus }),
+  setJoinDateRange: (joinDateRange) => set({ joinDateRange }),
+  setLoanStatus: (loanStatus) => set({ loanStatus }),
+  setTransactionCountMin: (transactionCountMin) => set({ transactionCountMin }),
+  setTransactionCountMax: (transactionCountMax) => set({ transactionCountMax }),
+}));

--- a/src/types/filter.type.ts
+++ b/src/types/filter.type.ts
@@ -1,0 +1,14 @@
+export type GenderType = 'ALL' | 'FEMALE' | 'MALE';
+export type UserStatusType = 'ALL' | 'ACTIVE' | 'INACTIVE';
+export type LoanStatusType = 'ALL' | 'TRUE' | 'FALSE';
+
+export type FilterType = {
+  name: string;
+  gender: GenderType;
+  birthRange: [string, string] | null;
+  userStatus: UserStatusType;
+  joinDateRange: [string, string] | null;
+  loanStatus: LoanStatusType;
+  transactionCountMin: number | null;
+  transactionCountMax: number | null;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #5

## 💜 작업 내용

- [x] 관리자 페이지 고객 관리 메뉴 UI 구현
- [x] 고객 관리 페이지 필터 UX 설계: "조회" 버튼 클릭 시에만 테이블 데이터 갱신
- [x] 입력 중인 필터와 실제 적용 필터 상태 분리 (useState + zustand)
- [x] 페이지 내 필터 UI 컴포넌트 및 데이터 테이블 구조화 및 스타일링

## ✅ PR Point

- sidebar.style.ts 스타일 일부를 개선했습니다. 기존에는 header의 높이(73px)를 빼주지않아서, 73px 만큼의 스크롤이 생기고있는 상태였습니다. 따라서, 최소 높이를 100vh - 73px로 할당해주어 불필요한 스크롤이 생기지 않도록 개선했습니다.
```
min-height: calc(100vh - 73px);
```
- 현재 PR은 실제 API를 연동하기 전입니다. 빠른 협업 및 피드백을 위해 UI만 구현해놓은 상태로 PR합니다. 추후 API 연동(axios), 스켈레톤 UI를 추가할 예정입니다.
- (참고) 입력 중인 필터(tempFilters)와 실제 쿼리에 적용되는 필터(zustand 상태)를 분리하여, 조회 조건 필터 값이 바뀔 때마다 즉시 데이터 쿼리가 실행되는 방식이 아닌, "조회" 버튼 클릭 시에만 데이터가 갱신되도록 로직을 작성했습니다.
	- 모든 필터 입력값은 useState로 관리 (tempFilters)
	- "조회" 버튼 클릭 시 zustand의 setter를 통해 전역 상태를 한 번에 업데이트 → useCustomersQuery의 queryKey가 바뀌며 쿼리 실행
  - 입력 도중에는 쿼리가 발생하지 않으며, "조회" 버튼을 눌러야만 테이블 데이터와 로딩 상태가 갱신됨

## 😡 Trouble Shooting

초기에 zustand의 필터 상태가 곧바로 쿼리 key에 반영되어, 필터 인풋 변경 시마다 즉시 useCustomersQuery가 재실행되는 문제가 있었습니다.
이를 해결하고자 입력값과 적용값을 분리하여, 입력은 local state, 적용은 zustand로 관리하도록 했습니다. 즉, "조회" 버튼 클릭 시에만 zustand setter를 호출하도록 개선했습니다.

## ☀ 스크린샷 / GIF / 화면 녹화

### 데이터가 없을 경우
<img width="1619" alt="스크린샷 2025-05-11 20 50 35" src="https://github.com/user-attachments/assets/bf89b8f0-0a92-4cc0-b9a8-6563975f5439" />

### 데이터가 존재할 경우 - 페이지 1
<img width="1619" alt="스크린샷 2025-05-11 20 51 26" src="https://github.com/user-attachments/assets/c9354496-7953-4461-a9ba-51bc6ead8468" />

### 데이터가 존재할 경우 - 페이지 3
<img width="1619" alt="스크린샷 2025-05-11 20 50 58" src="https://github.com/user-attachments/assets/7b4ee7df-7a1a-476f-b3f2-9e7ae5964e2d" />

## 🟢 다음 할 일
- 고객 상세보기 아이콘 컬럼 추가 (admin/customer-management/{customerId})
- API 연동(axios)
- 스켈레톤 UI 추가
- 관리자페이지 사이드바 구현