### PR TITLE
feat: GlobalStyle(데스크탑, 모바일 뷰) 분기 작업

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import '@/app/globals.css';
+import GlobalStyleProvider from '@/components/GlobalStyleProvider/GlobalStyleProvider';
+import { AppContainer } from '@/styles/MobileGlobalStyle/MobileGlobalStyle.style';
 
 export const metadata: Metadata = {
   title: 'FlexRate',
@@ -13,7 +15,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <GlobalStyleProvider />
+        <AppContainer>{children}</AppContainer>
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import '@/app/globals.css';
 import GlobalStyleProvider from '@/components/GlobalStyleProvider/GlobalStyleProvider';
-import { AppContainer } from '@/styles/MobileGlobalStyle/MobileGlobalStyle.style';
+import { AppContainer, InnerContainer } from '@/styles/MobileGlobalStyle/MobileGlobalStyle.style';
 
 export const metadata: Metadata = {
   title: 'FlexRate',
@@ -17,7 +17,9 @@ export default function RootLayout({
     <html lang="ko">
       <body>
         <GlobalStyleProvider />
-        <AppContainer>{children}</AppContainer>
+        <AppContainer>
+          <InnerContainer>{children}</InnerContainer>
+        </AppContainer>
       </body>
     </html>
   );

--- a/src/components/GlobalStyleProvider/GlobalStyleProvider.tsx
+++ b/src/components/GlobalStyleProvider/GlobalStyleProvider.tsx
@@ -8,7 +8,6 @@ import { usePathname } from 'next/navigation';
 const GlobalStyleProvider = () => {
   const pathname = usePathname();
   const isAdmin = pathname.startsWith('/admin');
-  console.log('GlobalStyleProvider loaded:', pathname);
 
   return isAdmin ? (
     <DesktopGlobalStyle />

--- a/src/components/GlobalStyleProvider/GlobalStyleProvider.tsx
+++ b/src/components/GlobalStyleProvider/GlobalStyleProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import DesktopGlobalStyle from '@/styles/DesktopGlobalStyle/DesktopGlobalStyle';
+import MobileGlobalStyle from '@/styles/MobileGlobalStyle/MobileGlobalStyle';
+import { css, Global } from '@emotion/react';
+import { usePathname } from 'next/navigation';
+
+const GlobalStyleProvider = () => {
+  const pathname = usePathname();
+  const isAdmin = pathname.startsWith('/admin');
+  console.log('GlobalStyleProvider loaded:', pathname);
+
+  return isAdmin ? (
+    <DesktopGlobalStyle />
+  ) : (
+    <>
+      <MobileGlobalStyle />
+    </>
+  );
+};
+
+export default GlobalStyleProvider;

--- a/src/styles/DesktopGlobalStyle/DesktopGlobalStyle.style.ts
+++ b/src/styles/DesktopGlobalStyle/DesktopGlobalStyle.style.ts
@@ -1,0 +1,29 @@
+import { css } from '@emotion/react';
+import { primitiveColor } from '../colors';
+
+export const desktopGlobalStyleCss = css`
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    background-color: ${primitiveColor.background.wt};
+    width: 100%;
+    margin: 0 auto;
+    min-height: 100vh;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+`;

--- a/src/styles/DesktopGlobalStyle/DesktopGlobalStyle.tsx
+++ b/src/styles/DesktopGlobalStyle/DesktopGlobalStyle.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { Global } from '@emotion/react';
+import { desktopGlobalStyleCss } from './DesktopGlobalStyle.style';
+
+const DesktopGlobalStyle = () => <Global styles={desktopGlobalStyleCss} />;
+
+export default DesktopGlobalStyle;

--- a/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
+++ b/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { primitiveColor } from '../colors';
+
+export const mobileGlobalStyleCss = css`
+  body {
+    margin: 0px auto;
+    padding: 0;
+    background-color: ${primitiveColor.gray[50]};
+    width: 100%;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+`;
+
+export const AppContainer = styled.div`
+  margin: 0px auto;
+  background-color: ${primitiveColor.background.wt};
+  min-height: calc(var(--vh, 1vh) * 100);
+  overflow-x: hidden;
+
+  width: 768px;
+  @media screen and (max-width: 768px) {
+    width: 100%;
+  }
+`;

--- a/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
+++ b/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
@@ -30,7 +30,7 @@ export const mobileGlobalStyleCss = css`
 
 export const AppContainer = styled.div`
   margin: 0px auto;
-  padding: 57px 22px 0px 22px;
+  padding: 0;
   background-color: ${primitiveColor.background.wt};
   min-height: calc(var(--vh, 1vh) * 100);
   overflow-x: hidden;
@@ -39,4 +39,9 @@ export const AppContainer = styled.div`
   @media screen and (max-width: 768px) {
     width: 100%;
   }
+`;
+
+export const InnerContainer = styled.div`
+  padding: 57px 22px 0;
+  box-sizing: border-box;
 `;

--- a/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
+++ b/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
@@ -30,6 +30,7 @@ export const mobileGlobalStyleCss = css`
 
 export const AppContainer = styled.div`
   margin: 0px auto;
+  padding: 57px 22px 0px 22px;
   background-color: ${primitiveColor.background.wt};
   min-height: calc(var(--vh, 1vh) * 100);
   overflow-x: hidden;

--- a/src/styles/MobileGlobalStyle/MobileGlobalStyle.tsx
+++ b/src/styles/MobileGlobalStyle/MobileGlobalStyle.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { Global } from '@emotion/react';
+import { mobileGlobalStyleCss } from './MobileGlobalStyle.style';
+
+const MobileGlobalStyle = () => <Global styles={mobileGlobalStyleCss} />;
+
+export default MobileGlobalStyle;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,4 +1,4 @@
-const primitiveColor = {
+export const primitiveColor = {
   background: {
     wt: '#ffffff',
     bk: '#000000',


### PR DESCRIPTION
## 🔥 Related Issues

- close #8 

## 💜 작업 내용

- [x] DesktopGlobalStyle
- [x] MobileGlobalStyle
- [x] GlobalStyleProvider

## ✅ PR Point

- desktop과 mobile일 때 각각의 GlobalStyle을 적용하였습니다.
- path 경로가 /admin으로 시작할 시, DesktopGlobalStyle로 띄우도록 하였습니다.
- MobileGlobalStyle은 body는 회색, 저희 어플리케이션이 보일 AppContainer에는 하얀색 배경으로 임의로 지정하였습니다. 어느 범위까지 어플리케이션 범위인지 눈으로 확인하기 위해 지정하였습니다.
- InnerContainer에 여러 디바이스의 콘텐트 위치를 통일하기 위해 피그마 상으로 나온 간격을 padding 값으로 지정하였습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
<img width="1362" alt="image" src="https://github.com/user-attachments/assets/4931cae7-daa4-4282-a818-eafa420a565b" />

<img width="598" alt="image" src="https://github.com/user-attachments/assets/b3d4424c-98e5-4fe5-bfac-89e436deb50f" />



## 📚 Reference

- [GlobalStyle emotion 공식문서](https://emotion.sh/docs/globals)
