### PR TITLE
fix: semanticColor token 수정 및 TextField errorMessage 위치 수정

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -32,7 +32,7 @@ export const ButtonContainer = styled.button<StyledButtonProps>`
 
   &:disabled {
     cursor: not-allowed;
-    background-color: ${semanticColor.button.inactive.default};
+    background-color: ${semanticColor.bgBtn.inactive.default};
     color: ${semanticColor.text.normal.sub3};
     border: none;
   }

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -13,7 +13,7 @@ const getBorderColor = (type: InputType = 'ACTIVE') => {
     case 'INACTIVE':
       return 'transparent';
     default:
-      return semanticColor.button.active.sub3;
+      return semanticColor.border.active.sub3;
   }
 };
 
@@ -32,7 +32,7 @@ export const InputContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1.5px;
+  gap: 2px;
 `;
 
 export const StyledInput = styled.input<{ $inputType: InputType }>`
@@ -54,7 +54,7 @@ export const StyledInput = styled.input<{ $inputType: InputType }>`
 
   &:focus {
     outline: none;
-    border: 1px solid ${semanticColor.button.active.sub3};
+    border: 1px solid ${semanticColor.border.active.sub3};
     color: ${semanticColor.text.normal.primary};
     background-color: ${semanticColor.bg.default};
   }
@@ -81,7 +81,7 @@ export const RightContent = styled.div`
   align-items: center;
 `;
 
-export const Label = styled.label<{ $inputType: InputType }>`
+export const Label = styled.label`
   ${typoStyleMap['body2_m']}
   padding-left: 6px;
   color: ${semanticColor.text.normal.primary};
@@ -98,14 +98,10 @@ export const LabelRow = styled.div`
   min-width: 0;
 `;
 
-export const HelperText = styled.div<{ $isError: boolean | undefined }>`
+export const HelperText = styled.div`
   ${typoStyleMap['caption1_m']}
   padding-right: 6px;
-  color: ${({ $isError }) =>
-    $isError ? semanticColor.text.state.textError : semanticColor.text.normal.sub3};
-  display: flex;
-  align-items: center;
-  gap: 5px;
+  color: ${semanticColor.text.normal.sub3};
 `;
 
 export const ChangeBtn = styled.button`
@@ -123,4 +119,18 @@ export const ChangeBtn = styled.button`
 
 export const TimeText = styled.div`
   color: ${semanticColor.text.state.textError};
+`;
+
+export const ErrorMessageWrapper = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+`;
+
+export const ErrorMessage = styled.div`
+  ${typoStyleMap['caption1_m']}
+  padding-right: 10px;
+  color: ${semanticColor.text.state.textError};
+  display: flex;
+  align-items: center;
+  gap: 5px;
 `;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -54,44 +54,33 @@ const TextFieldBox = () => {
 const Label = ({
   children,
   helperText,
-  errorMessage,
 }: {
   children: React.ReactNode;
   helperText?: React.ReactNode;
-  errorMessage?: React.ReactNode;
 }) => {
-  const { value, isDisabled, isError } = useTextFieldContext();
-
-  const inputType = getInputType({ isError, isDisabled, value }) ?? 'INACTIVE';
-
-  const rightText = isError ? errorMessage : helperText;
-
   return (
     <S.LabelRow>
-      <S.Label $inputType={inputType} htmlFor="text-field">
-        {children}
-      </S.Label>
-      {helperText && (
-        <S.HelperText $isError={isError}>
-          {isError && <ErrorIcon />}
-          {rightText}
-        </S.HelperText>
-      )}
+      <S.Label htmlFor="text-field">{children}</S.Label>
+      {helperText && <S.HelperText>{helperText}</S.HelperText>}
     </S.LabelRow>
   );
 };
 
 const RightIcon = () => {
-  const { rightContent } = useTextFieldContext();
+  const { rightContent, onChange } = useTextFieldContext();
 
   if (!rightContent) return null;
 
   switch (rightContent.type) {
     case 'CHANGE':
-      return <S.ChangeBtn type="button">변경</S.ChangeBtn>;
+      return (
+        <S.ChangeBtn type="button" onClick={rightContent.onClick}>
+          변경
+        </S.ChangeBtn>
+      );
 
     case 'DELETE':
-      return <DeleteIcon />;
+      return <DeleteIcon onClick={rightContent.onClick ?? (() => onChange(''))} />;
 
     case 'TIMER':
       return <S.TimeText>01:23</S.TimeText>;
@@ -101,7 +90,23 @@ const RightIcon = () => {
   }
 };
 
+const ErrorText = ({ message }: { message: string }) => {
+  const { isError } = useTextFieldContext();
+
+  if (!isError) return null;
+
+  return (
+    <S.ErrorMessageWrapper>
+      <S.ErrorMessage>
+        <ErrorIcon />
+        {message}
+      </S.ErrorMessage>
+    </S.ErrorMessageWrapper>
+  );
+};
+
 TextField.TextFieldBox = TextFieldBox;
 TextField.Label = Label;
+TextField.ErrorText = ErrorText;
 
 export default TextField;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -31,6 +31,7 @@ export const primitiveColor = {
   },
   red: {
     500: '#ff6969',
+    50: '#ffe1e1',
   },
 } as const;
 
@@ -59,14 +60,21 @@ export const semanticColor = {
   icon: {
     active: {
       default: primitiveColor.gray[900],
+      subtitle: primitiveColor.gray[200],
+      error: primitiveColor.red[500],
     },
+  },
+  card: {
+    card1: primitiveColor.background.wt,
   },
   border: {
     active: {
       primary: primitiveColor.blue.primary,
+      active: primitiveColor.red[500],
       default: primitiveColor.gray[900],
       sub2: primitiveColor.gray[600],
       sub3: primitiveColor.gray[300],
+      sub4: primitiveColor.gray[100],
     },
     inactive: {
       default: primitiveColor.gray[100],
@@ -75,11 +83,14 @@ export const semanticColor = {
       card1: primitiveColor.background.wt,
     },
   },
-  button: {
+  bgBtn: {
     active: {
       primary: primitiveColor.blue.primary,
       secondary: primitiveColor.blue[50],
-      sub2: primitiveColor.gray[600],
+      error: primitiveColor.red[50],
+      wt: primitiveColor.background.wt,
+      bk: primitiveColor.background.bk,
+      sub1: primitiveColor.gray[600],
       sub3: primitiveColor.gray[300],
     },
     inactive: {


### PR DESCRIPTION
## 🔥 Related Issues

- close #16 

## 💜 작업 내용

- [x] 변경된 semanticColor 토큰 수정
- [x] TextField errorMessage 위치 수정

## ✅ PR Point

- 디자인 시스템이 좀 바뀌어서 primitive와 semantic 컬러 값이 변경되었습니다.
- TextField 원래 구조상 HelperText 컴포넌트 안에 errorMessage props 전달 방식으로 에러날 때 띄우도록 만들었는데, 위치가 아예 바뀌었기에 ErrorText 컴포넌트로 따로 빼는 작업을 하였습니다. 
```tsx
// 변경 전
<TextField
  value={email}
  onChange={setEmail}
  isError={!!error.email}
  rightContent={{ type: 'CHANGE', onClick: () => setEmail('아앙') }}
>
  <TextField.Label>INACTIVE 상태 시</TextField.Label>
  <TextField.TextFieldBox />
  <TextField.HelperText errorMessage="올바른 값을 입력해주세요">[원]</TextField.HelperText>
</TextField>

// 변경 후
<TextField
  value={email}
  onChange={setEmail}
  isError={!!error.email}
  rightContent={{ type: 'CHANGE', onClick: () => setEmail('아앙') }}
>
  <TextField.Label helperText="[원]">INACTIVE 상태 시</TextField.Label>
  <TextField.TextFieldBox />
  <TextField.ErrorText message="올바른 값을 입력해주세요" />
</TextField>
```
- 변경 및 삭제 시, 버튼에 onClick 관련 코드를 추가했습니다. 삭제는 내부에서 바로 처리해줄 수 있기에 `onChange('')` 작업을 했습니다. 

## ☀ 스크린샷 / GIF / 화면 녹화

<img width="342" alt="image" src="https://github.com/user-attachments/assets/c19ee39a-ae8b-4b7b-ac0f-6beb6bdbee17" />

