### PR TITLE
feat: 관리자 페이지 - 고객 상세 조회 UI

### DIFF
--- a/src/apis/customer.ts
+++ b/src/apis/customer.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+/**
+ * 고객 상세 정보 조회
+ */
+const API_URL = process.env.API_URL || 'http://localhost:8080';
+
+export const fetchCustomerDetail = async (memberId: string, token: string | null) => {
+  try {
+    const { data } = await axios.get(`${API_URL}/api/admin/members/${memberId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return data;
+  } catch (error) {
+    throw new Error('고객 정보 조회 실패');
+  }
+};

--- a/src/apis/transactions.ts
+++ b/src/apis/transactions.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+/**
+ * 상환 내역 조회
+ */
+const API_URL = process.env.API_URL || 'http://localhost:8080';
+
+export const fetchTransactionHistory = async (
+  memberId: string,
+  token: string | null,
+  page: number,
+  size: number
+) => {
+  try {
+    const { data } = await axios.get(
+      `${API_URL}/api/admin/loans/members/${memberId}/transactions`,
+      {
+        params: { page, size },
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    return data;
+  } catch (error) {
+    throw new Error('거래 내역 조회 실패');
+  }
+};

--- a/src/app/admin/customer-management/[userId]/page.style.ts
+++ b/src/app/admin/customer-management/[userId]/page.style.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const PageContainer = styled.div`
+  padding: 30px;
+  width: 100%;
+`;
+
+export const ContentColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+export const HeaderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const Title = styled.h2`
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+`;

--- a/src/app/admin/customer-management/[userId]/page.tsx
+++ b/src/app/admin/customer-management/[userId]/page.tsx
@@ -63,7 +63,7 @@ const CustomerDetailPage = () => {
   const { data: transactionData, isLoading: transactionLoading } = useQuery({
     queryKey: ['transactionHistory', memberId, currentPage],
     queryFn: () => fetchTransactionHistory(memberId, accessToken, currentPage, PAGE_SIZE),
-    enabled: !!accessToken,
+    enabled: !!accessToken && !!customerData?.hasLoan,
     placeholderData: (previousData) => previousData,
     staleTime: 1000 * 60,
   });
@@ -92,13 +92,14 @@ const CustomerDetailPage = () => {
     status: string;
   }
 
-  const transactionTableData =
-    transactionData?.transactionHistories?.map((transaction: Transaction) => ({
-      ...transaction,
-      key: transaction.transactionId,
-      userId: transaction.memberId,
-      formattedDate: dayjs(transaction.occurredAt).format('YYYY-MM-DD'),
-    })) || [];
+  const transactionTableData = customerData?.hasLoan
+    ? transactionData?.transactionHistories?.map((transaction: Transaction) => ({
+        ...transaction,
+        key: transaction.transactionId,
+        userId: transaction.memberId,
+        formattedDate: dayjs(transaction.occurredAt).format('YYYY-MM-DD'),
+      })) || []
+    : [];
 
   const showPagination = transactionTableData.length > 0 && transactionData?.paginationInfo;
 

--- a/src/app/admin/customer-management/[userId]/page.tsx
+++ b/src/app/admin/customer-management/[userId]/page.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import { useQuery } from '@tanstack/react-query';
+import { Button, Spin } from 'antd';
+import dayjs from 'dayjs';
+import { useParams, useRouter } from 'next/navigation';
+
+import { TitleRow, Total } from '@/components/admin/Conditionbar/Conditionbar.style';
+import DataTable from '@/components/admin/DataTable/DataTable';
+import InfoBlock from '@/components/admin/InfoBlock/InfoBlock';
+import {
+  InfoContainer,
+  InfoGrid,
+  InfoItem,
+  InfoLoanGrid,
+  InfoLoanItem,
+  Label,
+  SectionTitle,
+  Value,
+} from '@/components/admin/InfoBlock/InfoBlock.style';
+import {
+  CONSUME_GOAL_LABEL_MAP,
+  CONSUMPTION_TYPE_LABEL_MAP,
+  SEX_LABEL_MAP,
+  MEMBERSTATUS_LABEL_MAP,
+} from '@/constants/customer.constant';
+
+import { PageContainer, ContentColumn, HeaderContainer, Title } from './page.style';
+
+/**
+ * 관리자 페이지 - 고객 상세 정보 조회 페이지
+ * @since 2025.05.12
+ * @author 허연규
+ */
+const CustomerDetailPage = () => {
+  const params = useParams();
+  const router = useRouter();
+  const memberId = params.userId as string;
+  const [currentPage, setCurrentPage] = useState(0);
+  const PAGE_SIZE = 4;
+
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+    if (!token) {
+      router.replace('/admin/not-found');
+    } else {
+      setAccessToken(token);
+    }
+  }, [router]);
+
+  // 고객 상세 정보 조회 API 호출
+  const {
+    data: customerData,
+    isLoading: customerLoading,
+    error: customerError,
+  } = useQuery({
+    queryKey: ['customerDetail', memberId],
+    queryFn: () => fetchCustomerDetail(memberId, accessToken),
+    enabled: !!accessToken,
+  });
+
+  // 거래 내역 조회 API 호출
+  const { data: transactionData, isLoading: transactionLoading } = useQuery({
+    queryKey: ['transactionHistory', memberId, currentPage],
+    queryFn: async () => {
+      const url = `http://localhost:8080/api/admin/loans/members/${memberId}/transactions?page=${currentPage}&size=${PAGE_SIZE}`;
+
+      const res = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      if (!res.ok) throw new Error('Failed to fetch transaction history');
+      return res.json();
+    },
+    enabled: !!accessToken,
+    placeholderData: (previousData) => previousData,
+    staleTime: 1000 * 60,
+  });
+
+  // 뒤로가기 핸들러
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  const transactionColumns = [
+    { title: '거래 내역 ID', dataIndex: 'transactionId', key: 'transactionId', width: 120 },
+    { title: '대출 신청 ID', dataIndex: 'applicationId', key: 'applicationId', width: 120 },
+    { title: '회원 ID', dataIndex: 'memberId', key: 'memberId', width: 100 },
+    { title: '거래 유형', dataIndex: 'type', key: 'type', width: 100 },
+    { title: '거래 금액', dataIndex: 'amount', key: 'amount', width: 120 },
+    { title: '발생일시', dataIndex: 'formattedDate', key: 'occurredAt', width: 120 },
+    { title: '상태', dataIndex: 'status', key: 'status', width: 100 },
+  ];
+
+  interface Transaction {
+    transactionId: string;
+    applicationId: string;
+    memberId: string;
+    type: string;
+    amount: number;
+    occurredAt: string;
+    status: string;
+  }
+
+  const transactionTableData =
+    transactionData?.transactionHistories?.map((transaction: Transaction) => ({
+      ...transaction,
+      key: transaction.transactionId,
+      userId: transaction.memberId,
+      formattedDate: dayjs(transaction.occurredAt).format('YYYY-MM-DD'),
+    })) || [];
+
+  const showPagination = transactionTableData.length > 0 && transactionData?.paginationInfo;
+
+  const paginationInfo = showPagination
+    ? {
+        currentPage: (transactionData.paginationInfo.currentPage || 0) + 1,
+        pageSize: PAGE_SIZE,
+        totalElements: transactionData.paginationInfo.totalElements,
+        totalPages: transactionData.paginationInfo.totalPages,
+        onChange: (page: number) => setCurrentPage(page - 1),
+      }
+    : undefined;
+
+  if (customerLoading) {
+    return (
+      <PageContainer>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '50vh',
+          }}
+        >
+          <Spin size="large" />
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (customerError || !customerData) {
+    return (
+      <PageContainer>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '60vh',
+            gap: '16px',
+          }}
+        >
+          <div>고객 정보를 불러오는데 실패했습니다.</div>
+          <Button type="primary" onClick={handleGoBack}>
+            목록으로 돌아가기
+          </Button>
+        </div>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <ContentColumn>
+        <HeaderContainer>
+          <Button icon={<ArrowLeftOutlined />} onClick={handleGoBack} />
+          <Title>고객 상세 조회</Title>
+        </HeaderContainer>
+
+        {/* 고객 기본 정보 블록 */}
+        <InfoBlock>
+          <InfoGrid columns={6}>
+            <InfoItem>
+              <Label>이름</Label>
+              <Value>{customerData.name}</Value>
+            </InfoItem>
+            <InfoItem>
+              <Label>성별</Label>
+              <Value>{SEX_LABEL_MAP[customerData.sex]}</Value>
+            </InfoItem>
+            <InfoItem>
+              <Label>사용자 상태</Label>
+              <Value>{MEMBERSTATUS_LABEL_MAP[customerData.status]}</Value>
+            </InfoItem>
+            <InfoItem>
+              <Label>생년월일</Label>
+              <Value>{customerData.birthDate}</Value>
+            </InfoItem>
+            <InfoItem>
+              <Label>가입일</Label>
+              <Value>{dayjs(customerData.createdAt).format('YYYY-MM-DD')}</Value>
+            </InfoItem>
+            <InfoItem>
+              <Label>대출 거래 횟수</Label>
+              <Value>{customerData.loanTransactionCount}</Value>
+            </InfoItem>
+          </InfoGrid>
+        </InfoBlock>
+        <div style={{ display: 'flex', gap: '32px' }}>
+          {/* 고객 소비 성향 정보 블록 */}
+          <div style={{ flex: '0 0 500px' }}>
+            <InfoBlock>
+              <SectionTitle>고객 정보</SectionTitle>
+              <InfoContainer>
+                <InfoGrid columns={1}>
+                  <InfoItem>
+                    <Label>소비 성향</Label>
+                    <Value>{CONSUMPTION_TYPE_LABEL_MAP[customerData.consumptionType]}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>소비 목표</Label>
+                    <Value>{CONSUME_GOAL_LABEL_MAP[customerData.consumeGoal]}</Value>
+                  </InfoItem>
+                </InfoGrid>
+              </InfoContainer>
+            </InfoBlock>
+          </div>
+          {/* 대출 정보 블록 - 대출이 있는 경우에만 표시 */}
+          {customerData.hasLoan && (
+            <div style={{ flex: 1 }}>
+              <InfoBlock>
+                <SectionTitle>진행중 대출 상태</SectionTitle>
+                <InfoContainer>
+                  <InfoLoanGrid>
+                    <InfoLoanItem>
+                      <Label>대출 시작일</Label>
+                      <Value>{dayjs(customerData.loanStartDate).format('YYYY-MM-DD')}</Value>
+                    </InfoLoanItem>
+                    <InfoLoanItem>
+                      <Label>대출 종료일</Label>
+                      <Value>{dayjs(customerData.loanEndDate).format('YYYY-MM-DD')}</Value>
+                    </InfoLoanItem>
+                    <InfoLoanItem>
+                      <Label>대출 원금</Label>
+                      <Value>{customerData.loanAmount.toLocaleString()}원</Value>
+                    </InfoLoanItem>
+                    <InfoLoanItem>
+                      <Label>월 납입 금액</Label>
+                      <Value>{customerData.monthlyPayment.toLocaleString()}원</Value>
+                    </InfoLoanItem>
+                    <InfoLoanItem>
+                      <Label>납입일</Label>
+                      <Value>매달 {customerData.paymentDue}일</Value>
+                    </InfoLoanItem>
+                    <InfoLoanItem>
+                      <Label>대출 이자율</Label>
+                      <Value>{customerData.interestRate}%</Value>
+                    </InfoLoanItem>
+                    <InfoLoanItem>
+                      <Label>신용평가 점수</Label>
+                      <Value>{customerData.creditScore}점</Value>
+                    </InfoLoanItem>
+                  </InfoLoanGrid>
+                </InfoContainer>
+              </InfoBlock>
+            </div>
+          )}
+        </div>
+
+        {/* 상환 내역 테이블 */}
+        <TitleRow>
+          <Title>상환 내역 조회</Title>
+          {paginationInfo?.totalElements && <Total>{paginationInfo.totalElements}회</Total>}
+        </TitleRow>
+        <DataTable
+          data={transactionTableData || []}
+          loading={transactionLoading}
+          columnMetas={transactionColumns}
+          paginationInfo={paginationInfo}
+          linkPrefix="/admin/customers/"
+        />
+      </ContentColumn>
+    </PageContainer>
+  );
+};
+
+// 고객 상세 정보 조회 API 호출 함수
+const fetchCustomerDetail = async (memberId: string, adminToken: string | null) => {
+  const url = `http://localhost:8080/api/admin/members/${memberId}`;
+
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${adminToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('고객 정보 조회 실패');
+  }
+
+  return res.json();
+};
+
+export default CustomerDetailPage;

--- a/src/components/admin/ErrorBlock/ErrorBlock.style.ts
+++ b/src/components/admin/ErrorBlock/ErrorBlock.style.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+export const ErrorWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 60vh;
+  width: 100%;
+  gap: 16px;
+  text-align: center;
+`;
+
+export const ErrorMessage = styled.div`
+  font-size: 16px;
+  color: #595959;
+  margin-bottom: 8px;
+`;

--- a/src/components/admin/ErrorBlock/ErrorBlock.tsx
+++ b/src/components/admin/ErrorBlock/ErrorBlock.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+
+import { Button } from 'antd';
+
+import { ErrorWrapper, ErrorMessage } from './ErrorBlock.style';
+
+interface Props {
+  message: string;
+  onRetry: () => void;
+  buttonText?: string;
+}
+
+const ErrorBlock = ({ message, onRetry, buttonText = '목록으로 돌아가기' }: Props) => {
+  return (
+    <ErrorWrapper>
+      <ErrorMessage>{message}</ErrorMessage>
+      <Button type="primary" onClick={onRetry}>
+        {buttonText}
+      </Button>
+    </ErrorWrapper>
+  );
+};
+
+export default ErrorBlock;

--- a/src/components/admin/InfoBlock/InfoBlock.style.ts
+++ b/src/components/admin/InfoBlock/InfoBlock.style.ts
@@ -1,0 +1,112 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const shimmer = keyframes`
+    0% {
+        transform: translateX(-100%);
+    }
+    100% {
+        transform: translateX(100%);
+    }
+`;
+
+export const StyledInfoBlock = styled.div`
+  width: 100%;
+  padding: 20px 30px;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const SkeletonInfoBox = styled.div`
+  width: 100%;
+  padding: 20px 30px;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  background: #f9f9f9;
+  position: relative;
+  overflow: hidden;
+  min-height: 120px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 0.6) 50%,
+      rgba(255, 255, 255, 0) 100%
+    );
+    background-size: 468px 100%;
+    animation: ${shimmer} 1.8s infinite ease-in-out;
+  }
+`;
+
+export const SectionTitle = styled.div`
+  display: inline-block;
+  padding: 4px 12px;
+  border: 1px solid #1677ff;
+  color: #1677ff;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 150%;
+  width: fit-content;
+  position: relative;
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const InfoGrid = styled.div<{ columns?: number }>`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  ${({ columns }) =>
+    columns === 1 &&
+    `
+    flex-direction: column;
+  `}
+`;
+
+export const InfoLoanGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+`;
+
+export const InfoItem = styled.div`
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-right: 10px;
+`;
+
+export const InfoLoanItem = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const Label = styled.div`
+  font-size: 14px;
+  font-weight: 500;
+  color: #2f3439;
+  margin-right: 10px;
+`;
+
+export const Value = styled.div`
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+`;

--- a/src/components/admin/InfoBlock/InfoBlock.tsx
+++ b/src/components/admin/InfoBlock/InfoBlock.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+import { StyledInfoBlock, SkeletonInfoBox } from '@/components/admin/InfoBlock/InfoBlock.style';
+
+type InfoBlockProps = {
+  children: React.ReactNode;
+};
+
+const InfoBlock = ({ children }: InfoBlockProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return isLoading ? <SkeletonInfoBox /> : <StyledInfoBlock>{children}</StyledInfoBlock>;
+};
+
+export default InfoBlock;

--- a/src/constants/customer.constant.ts
+++ b/src/constants/customer.constant.ts
@@ -1,0 +1,40 @@
+// 소비 성향 라벨 매핑
+export const CONSUMPTION_TYPE_LABEL_MAP: Record<string, string> = {
+  CONSERVATIVE: '절약형',
+  PRACTICAL: '실용형',
+  BALANCED: '균형형',
+  CONSUMPTION_ORIENTED: '일반형',
+};
+
+// 소비 목표 라벨 매핑
+export const CONSUME_GOAL_LABEL_MAP: Record<string, string> = {
+  NO_SPENDING_TODAY: '오늘 하루, 지출 없이 보내고싶어요.',
+  LIMIT_DAILY_MEAL: '하루 식비로 10,000원 이상 쓰고싶지 않아요.',
+  SAVE_70_PERCENT: '수입 70% 이상을 저축해요.',
+  INCOME_OVER_EXPENSE: '지출보다 수익이 많아요.',
+  ONLY_PUBLIC_TRANSPORT: '대중교통만 이용해요.',
+  COMPARE_BEFORE_BUYING: '구매하기 전에 가격을 비교해요.',
+  HAS_HOUSING_SAVING: '주택청약을 들고 있어요.',
+  CLOTHING_UNDER_100K: '10만원 이하의 의류를 소비해요.',
+  ONE_CATEGORY_SPEND: '오늘은 하나의 카테고리에만 소비해보세요.',
+  SMALL_MONTHLY_SAVE: '매달 소액의 저축을 목표로 해요.',
+  NO_USELESS_ELECTRONICS: '필요하지 않은 가전제품은 구매하지 않아요.',
+  OVER_10_PERCENT: '평균 지출의 10% 이상 소비해요.',
+  NO_EXPENSIVE_DESSERT: '만원을 넘기는 디저트와 커피는 사치에요.',
+  NO_OVER_50K_PER_DAY: '하루에 5만원 이상의 무리한 소비는 하지 않아요.',
+  SUBSCRIPTION_UNDER_50K: '월 구독비로 5만원을 넘기지 않아요.',
+  MEAL_UNDER_20K: '2만원이 넘는 밥값은 소비하지 않는 편이에요.',
+};
+
+// 성별 라벨 매핑
+export const SEX_LABEL_MAP: Record<string, string> = {
+  MALE: '남',
+  FEMALE: '여',
+};
+
+// 상태 라벨 매핑
+export const MEMBERSTATUS_LABEL_MAP: Record<string, string> = {
+  ACTIVE: '활성화',
+  WITHDRAWN: '탈퇴',
+  SUSPENDED: '이용정지',
+};


### PR DESCRIPTION
## 🔥 Related Issues

- close #7 

## 💜 작업 내용

- [x] 고객 상세 조회 UI
- [x] 상환 내역 조회 UI
- [x] API 연동
- [x] API 분리
- [x] ErrorBlock 컴포넌트 생성
- [x] hasLoan이 false일 경우 고객 정보 블럭의 너비를 100%으로 변경
- [x] token 명칭 accessToken으로 통일
- [x] hasLoan이 false일 때도 데이터에 상환 내역이 존재할 경우 테이블에 출력되는 오류 수정

## ✅ PR Point

- customer-management/[userId]로 page.tsx, page.style.ts 생성했습니다.

- 공통 컴포넌트인 Conditionbar로 상세 조회 쪽 구현하려고 했는데 조금 어려움을 겪어서 InfoBlock이라는 컴포넌트를 생성, 이를 기반으로 고객 기본 정보와 고객 소비 성향 정보, 고객 대출 정보를 구현했습니다. 초반에 각각 컴포넌트를 만들어 적용했던 걸 공통 컴포넌트를 사용하기 위해 바꾸었습니다.

- 현재 figma와 최대한 비슷하게 구현해보려고 고객 소비 성향 정보와 고객 대출 정보 쪽 div에 각각 style={{ flex: '0 0 500px' }}, style={{ flex: 1 }}를 추가하였습니다. 안의 요소들 배열이 어떻게 되는지 확인하려고 추가한 거여서 다른 방식으로 바꿔도 좋을 것 같습니다.

- constants 폴더에 customer.constant.ts를 추가하였습니다. 소비 성향, 소비 목표, 성별, 회원 상태 라벨을 매핑해주기 위한 용도입니다.

- 상환 내역 조회는 기존에 있던 공통 컴포넌트인 DataTable을 사용하여 구현했습니다.

- 고객 상세 조회 옆의 뒤로가기 버튼을 클릭하면, 바로 이전의 페이지로 돌아갑니다. 이전 페이지를 customer-management 페이지로 한정하지 않은 것은 대출 신청 현황 페이지에서도 상세 조회 페이지로 접속하기 때문입니다.

- 고객 조회에 실패할 경우, 화면에 문구와 목록으로 돌아가기 버튼이 뜨게 해두었는데 필요가 없을 것 같다면 지우는 것도 좋을 것 같습니다.

- 테스트할 때, POST http://localhost:8080/api/auth/generate-dev-token 로 토큰 발급 받아서 Local storage에 accessToken이랑 adminToken 값을 넣어주었습니다.

- 민지님이 올려주신 flyway 마이그레이션 파일 작성 pr의 V1__init.sql, V999__init_dev_dummy_data.sql와 추가 insert문을 넣어주었습니다. 스크린샷과 동일하게 테스트 해보고 싶으시다면 해당 insert문을 사용해주세요.
```
insert into loan_transaction (amount, application_id, member_id, occurred_at, status, type)
values
    (300000, 1, 6, date_sub(now(), interval 19 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 18 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 17 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 16 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 15 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 14 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 13 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 12 day), 'NORMAL', 'REPAYMENT'),
    (300000, 1, 6, date_sub(now(), interval 11 day), 'NORMAL', 'REPAYMENT');
```


## 😡 Trouble Shooting

- 상환 내역 조회를 구현하는 동안, pageSize를 4로 지정해주자 테이블이 pageSize가 8일 때의 크기에서 더 줄어들지 않아, 페이지 1번부터 아래에 빈 row가 추가되는 상황이 발생했습니다. console에서 log를 찍어 확인해봤을 때 pageSize는 전부 제대로 넘어가는 걸 확인할 수 있었고, 코드를 찾아보다 보니 DataTable의 TABLE_MIN_HEIGHT 값이 pageSize가 4일 때의 테이블 높이보다 높게 지정된 것을 발견하여 const TABLE_MIN_HEIGHT = 200;로 바꾼 뒤 진행했습니다. commit에는 적용하지 않았으므로 테스트 해보실 때 해당 값을 변경하신 후 진행하시길 추천드립니다.

## ☀ 스크린샷 / GIF / 화면 녹화

구현된 페이지(상환 내역 조회 1페이지와 4페이지 비교)
![image](https://github.com/user-attachments/assets/d2c23023-e217-4c4d-9808-3a60c1a39042)
![image](https://github.com/user-attachments/assets/94e97f99-d0db-4677-a7d8-f4c9e8edfb79)


페이지 상단의 뒤로가기(←) 버튼을 누를 경우, 바로 이전 페이지가 나옴
![image](https://github.com/user-attachments/assets/d7bcbccf-a815-4b23-a1f4-d645bb24dec4)


조회 실패 시
![image](https://github.com/user-attachments/assets/b9046be6-4694-4ae1-99c2-ee9c4e1f87f9)


대출 중이 아닐 시
![image](https://github.com/user-attachments/assets/cacdb2b0-e9a9-4945-a1d1-afdffb02f702)


고객 정보 블럭 너비 증가
![image](https://github.com/user-attachments/assets/3a151bc1-98b6-44d0-a84a-0b1a5d33bbae)


