### PR TITLE
feat: 회원가입 페이지 - API 연동

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -5,6 +5,16 @@ import axios from 'axios';
  */
 const API_URL = process.env.API_URL || 'http://localhost:8080';
 
+// axios 인스턴스 생성 (공통 설정 포함)
+const apiClient = axios.create({
+  baseURL: API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+
+
 // 로그인 유저 정보 반환
 export async function getMyPageUser(token: string) {
   const { data } = await axios.get(`${API_URL}/api/members/mypage`, {
@@ -36,7 +46,21 @@ export async function signupUser(data: SignupRequest): Promise<SignupResponse> {
 }
 
 // 이메일 인증 요청
+export interface SendEmailRequest {
+  email: string;
+}
+export async function sendEmailVerificationCode(data: SendEmailRequest): Promise<void> {
+  await apiClient.post('/api/auth/email/send', data);
+}
 
+// 이메일 인증번호 검증
+export interface VerifyEmailCodeRequest {
+  email: string;
+  code: string;
+}
+export async function verifyEmailCode(data: VerifyEmailCodeRequest): Promise<void> {
+  await apiClient.post('/api/auth/email/verification', data);
+}
 
 // 이메일 변경 요청
 export async function requestEmailChange(token: string, email: string) {

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -3,7 +3,9 @@ import axios from 'axios';
 /**
  * 인증 관련 API
  */
-const API_URL = process.env.API_URL || 'http://localhost:8080';
+const API_URL = 'http://localhost:8080';
+console.log('API_URL', API_URL);
+
 
 // 공통 설정 포함 axios 인스턴스 생성 (baseURL, JSON 헤더)
 const apiClient = axios.create({

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -70,3 +70,24 @@ export async function requestEmailChange(token: string, email: string) {
 
   return data;
 }
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken?: string;
+  user: {
+    name: string;
+    email: string;
+    consumeGoal: string;
+    consumptionType: string;
+  };
+}
+
+export async function loginUser(data: LoginRequest): Promise<LoginResponse> {
+  const response = await apiClient.post('/api/auth/login/password', data);
+  return response.data;
+}

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
  */
 const API_URL = process.env.API_URL || 'http://localhost:8080';
 
-// axios 인스턴스 생성 (공통 설정 포함)
+// 공통 설정 포함 axios 인스턴스 생성 (baseURL, JSON 헤더)
 const apiClient = axios.create({
   baseURL: API_URL,
   headers: {
@@ -13,9 +13,7 @@ const apiClient = axios.create({
   },
 });
 
-
-
-// 로그인 유저 정보 반환
+// 토큰 필요 API는 직접 axios 호출 (헤더 커스텀용)
 export async function getMyPageUser(token: string) {
   const { data } = await axios.get(`${API_URL}/api/members/mypage`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -24,7 +22,6 @@ export async function getMyPageUser(token: string) {
   return data;
 }
 
-
 export interface SignupRequest {
   email: string;
   password: string;
@@ -32,7 +29,7 @@ export interface SignupRequest {
   name: string;
   birthDate: string;
   consumptionType: string;
-  consumeGoal: string
+  consumeGoal: string;
 }
 
 export interface SignupResponse {
@@ -40,32 +37,35 @@ export interface SignupResponse {
   email: string;
 }
 
+// 회원가입 API는 공통 인스턴스 사용
 export async function signupUser(data: SignupRequest): Promise<SignupResponse> {
-  const response = await axios.post(`${API_URL}/api/auth/signup/password`, data);
+  const response = await apiClient.post('/api/auth/signup/password', data);
   return response.data;
 }
 
-// 이메일 인증 요청
 export interface SendEmailRequest {
   email: string;
 }
+
+// 이메일 인증 요청 - 인스턴스 사용
 export async function sendEmailVerificationCode(data: SendEmailRequest): Promise<void> {
   await apiClient.post('/api/auth/email/send', data);
 }
 
-// 이메일 인증번호 검증
 export interface VerifyEmailCodeRequest {
   email: string;
   code: string;
 }
+
+// 이메일 인증번호 검증 - 인스턴스 사용
 export async function verifyEmailCode(data: VerifyEmailCodeRequest): Promise<void> {
   await apiClient.post('/api/auth/email/verification', data);
 }
 
-// 이메일 변경 요청
+// 이메일 변경 요청 - 토큰 헤더 필요해서 직접 호출
 export async function requestEmailChange(token: string, email: string) {
   const { data } = await axios.patch(`${API_URL}/api/members/mypage`, { email }, {
-      headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}` },
   });
 
   return data;
@@ -87,6 +87,7 @@ export interface LoginResponse {
   };
 }
 
+// 로그인 API - 공통 인스턴스 사용
 export async function loginUser(data: LoginRequest): Promise<LoginResponse> {
   const response = await apiClient.post('/api/auth/login/password', data);
   return response.data;

--- a/src/app/auth/login.tsx
+++ b/src/app/auth/login.tsx
@@ -1,0 +1,6 @@
+import axios from '../../lib/axios';
+
+export const login = async (email: string, password: string) => {
+  const res = await axios.post('/auth/login', { email, password });
+  return res.data;
+};

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 import React, { useState } from 'react';
-import { Wrapper } from '@/components/loanApplicationFunnel/LoanApplicationFunnel.style';
+
 import Header from '@/components/Header/Header';
-import LoginSelector from '@/components/login/LoginSelector/LoginSelector';
+import { Wrapper } from '@/components/loanApplicationFunnel/LoanApplicationFunnel.style';
 import LoginForm from '@/components/login/LoginForm/LoginForm';
+import LoginSelector from '@/components/login/LoginSelector/LoginSelector';
 
 type Step = 'selector' | 'form';
 
-export default function LoginPage() {
+const LoginPage = () => {
   const [step, setStep] = useState<Step>('selector');
 
   return (
@@ -25,4 +26,6 @@ export default function LoginPage() {
       {step === 'form' && <LoginForm />}
     </Wrapper>
   );
-}
+};
+
+export default LoginPage;

--- a/src/app/auth/signup.tsx
+++ b/src/app/auth/signup.tsx
@@ -6,7 +6,7 @@ export interface SignupPayload {
   name: string;
   birthDate: string;
   gender: 'male' | 'female';
-  goal: 'save' | 'spend' | 'track'; // 예시
+  goal: 'CONSERVATIVE' | 'PRACTICAL' | 'BALANCED' | 'CONSUMPTION_ORIENTED';
 }
 
 export const signup = async (data: SignupPayload) => {

--- a/src/app/auth/signup.tsx
+++ b/src/app/auth/signup.tsx
@@ -1,0 +1,15 @@
+import axios from '../../lib/axios';
+
+export interface SignupPayload {
+  email: string;
+  password: string;
+  name: string;
+  birthDate: string;
+  gender: 'male' | 'female';
+  goal: 'save' | 'spend' | 'track'; // 예시
+}
+
+export const signup = async (data: SignupPayload) => {
+  const response = await axios.post('/auth/signup', data);
+  return response.data;
+};

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,17 +1,20 @@
 'use client';
-import React from 'react';
-import { useFunnel } from '@use-funnel/browser';
-import { Wrapper } from '@/components/loanApplicationFunnel/LoanApplicationFunnel.style';
-import Header from '@/components/Header/Header';
-import EmailForm from '@/components/signup/EmailForm/EmailForm';
-import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
-import { InfoForm } from '@/components/signup/InfoForm/InfoForm';
-import { SignupSteps } from '@/types/funnel.type';
-import Agreement from '@/components/signup/AgreeForConsumptionType/AgreeForConsumptionType';
-import ConsumptionResult from '@/components/signup/ConsumptionResult/ConsumptionResult';
-import ConsumptionGoal from '@/components/signup/ConsumptionGoal/ConsumptionGoal';
 
-export default function SignupPage() {
+import React from 'react';
+
+import { useFunnel } from '@use-funnel/browser';
+
+import Header from '@/components/Header/Header';
+import { Wrapper } from '@/components/loanApplicationFunnel/LoanApplicationFunnel.style';
+import Agreement from '@/components/signup/AgreeForConsumptionType/AgreeForConsumptionType';
+import ConsumptionGoal from '@/components/signup/ConsumptionGoal/ConsumptionGoal';
+import ConsumptionResult from '@/components/signup/ConsumptionResult/ConsumptionResult';
+import EmailForm from '@/components/signup/EmailForm/EmailForm';
+import { InfoForm } from '@/components/signup/InfoForm/InfoForm';
+import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
+import { SignupSteps } from '@/types/funnel.type';
+
+const SignupPage = (): React.JSX.Element => {
   const funnel = useFunnel<SignupSteps>({
     id: 'signup',
     initial: { step: '이메일인증', context: { email: '' } },
@@ -22,7 +25,7 @@ export default function SignupPage() {
       <Header backIcon={funnel.step !== '이메일인증'} />
       <funnel.Render
         이메일인증={funnel.Render.with({
-          render: ({ context }) => (
+          render: () => (
             <EmailForm
               onNext={(email) =>
                 funnel.history.push('비밀번호설정', (prev) => ({ ...prev, email }))
@@ -35,27 +38,20 @@ export default function SignupPage() {
             <PasswordForm
               email={context.email}
               onNext={({ password, method }) => {
-                if (method === '간편비밀번호') {
-                  funnel.history.push('간편비밀번호설정', (prev) => ({
-                    ...prev,
-                    ...context,
-                    password,
-                    method,
-                  }));
-                } else {
-                  funnel.history.push('내정보입력', (prev) => ({
-                    ...prev,
-                    ...context,
-                    password,
-                    method,
-                  }));
-                }
+                const nextStep =
+                  method === '간편비밀번호' ? '간편비밀번호설정' : '내정보입력';
+                funnel.history.push(nextStep, (prev) => ({
+                  ...prev,
+                  ...context,
+                  password,
+                  method,
+                }));
               }}
             />
           ),
         })}
         간편비밀번호설정={funnel.Render.with({
-          render: ({ context }) => (
+          render: () => (
             <div>
               <h2>간편 비밀번호 설정</h2>
             </div>
@@ -66,7 +62,9 @@ export default function SignupPage() {
             <InfoForm
               defaultValues={{
                 gender: context.gender as '남성' | '여성' | undefined,
-                birthDate: context.birthDate ? Number(context.birthDate) : undefined,
+                birthDate: context.birthDate
+                  ? Number(context.birthDate)
+                  : undefined,
                 name: context.name,
               }}
               onNext={({ gender, birthDate, name }) =>
@@ -82,12 +80,11 @@ export default function SignupPage() {
           ),
         })}
         소비성향체크={funnel.Render.with({
-          render: ({ context }) => (
+          render: () => (
             <Agreement
               onNext={() =>
                 funnel.history.push('소비성향결과', (prev) => ({
                   ...prev,
-                  ...context,
                   agreement: true,
                 }))
               }
@@ -95,12 +92,11 @@ export default function SignupPage() {
           ),
         })}
         소비성향결과={funnel.Render.with({
-          render: ({ context }) => (
+          render: () => (
             <ConsumptionResult
               onNext={() =>
                 funnel.history.push('소비목적결과', (prev) => ({
                   ...prev,
-                  ...context,
                   consumptionGoal: '',
                 }))
               }
@@ -109,10 +105,14 @@ export default function SignupPage() {
         })}
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
-            <ConsumptionGoal onComplete={() => console.log('회원가입 완료', context)} />
+            <ConsumptionGoal
+              onComplete={() => console.log('회원가입 완료', context)}
+            />
           ),
         })}
       />
     </Wrapper>
   );
-}
+};
+
+export default SignupPage;

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -10,7 +10,7 @@ import Agreement from '@/components/signup/AgreeForConsumptionType/AgreeForConsu
 import ConsumptionGoal from '@/components/signup/ConsumptionGoal/ConsumptionGoal';
 import ConsumptionResult from '@/components/signup/ConsumptionResult/ConsumptionResult';
 import EmailForm from '@/components/signup/EmailForm/EmailForm';
-import { InfoForm } from '@/components/signup/InfoForm/InfoForm';
+import InfoForm from '@/components/signup/InfoForm/InfoForm';
 import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
 import { SignupSteps } from '@/types/funnel.type';
 
@@ -67,7 +67,7 @@ const SignupPage = (): React.JSX.Element => {
                   : undefined,
                 name: context.name,
               }}
-              onNext={({ gender, birthDate, name }) =>
+              onNext={({ gender, birthDate, name }: { gender: string; birthDate: number; name: string }) =>
                 funnel.history.push('소비성향체크', (prev) => ({
                   ...prev,
                   ...context,

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -119,8 +119,13 @@ const SignupPage = (): React.JSX.Element => {
             <ConsumptionGoal
               onComplete={async (selectedGoal) => {
                 const signupData = {
-                  ...context,
-                  consumptionGoal: selectedGoal,
+                  email: context.email,
+                  password: context.password,
+                  sex: context.gender,
+                  name: context.name,
+                  birthDate: context.birthDate,
+                  consumptionType: context.cosumptionType,
+                  consumeGoal: selectedGoal,
                 };
 
                 console.log('서버로 보내는 회원가입 데이터:', signupData);

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 
 import { useFunnel } from '@use-funnel/browser';
 
+
+
 function reverseMap<T extends Record<string, string>>(map: T, value: string): keyof T | undefined {
   return (Object.entries(map).find(([, v]) => v === value)?.[0]) as keyof T | undefined;
 }
@@ -17,8 +19,7 @@ import EmailForm from '@/components/signup/EmailForm/EmailForm';
 import InfoForm from '@/components/signup/InfoForm/InfoForm';
 import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
 import { ConsumptionType } from '@/constants/auth.constant';
-import {
-  CONSUMPTION_TYPE_LABEL_MAP,
+import { CONSUMPTION_TYPE_LABEL_MAP ,
   CONSUME_GOAL_LABEL_MAP,
 } from '@/constants/customer.constant';
 import { api } from '@/lib/axios';
@@ -38,6 +39,7 @@ const SignupPage = (): React.JSX.Element => {
           render: () => (
             <EmailForm
               onNext={(email) =>
+                // 이메일 입력 후 비밀번호 설정 단계로 이동
                 funnel.history.push('비밀번호설정', (prev) => ({ ...prev, email }))
               }
             />
@@ -50,6 +52,7 @@ const SignupPage = (): React.JSX.Element => {
               onNext={({ password, method }) => {
                 const nextStep =
                   method === '간편비밀번호' ? '간편비밀번호설정' : '내정보입력';
+                // 비밀번호 설정 후 선택된 방법에 따라 다음 단계로 이동
                 funnel.history.push(nextStep, (prev) => ({
                   ...prev,
                   ...context,
@@ -72,21 +75,27 @@ const SignupPage = (): React.JSX.Element => {
             <InfoForm
               defaultValues={{
                 gender: context.gender as 'MALE' | 'FEMALE',
+                // number 타입의 birthDate를 "YYYY-MM-DD" 문자열로 변환
                 birthDate:
                   typeof context.birthDate === 'number'
                     ? new Date(context.birthDate).toISOString().slice(0, 10)
                     : context.birthDate ?? '',
                 name: context.name ?? '',
               }}
-              onNext={({ gender, birthDate, name }) => {
-                funnel.history.push('소비성향체크', (prev) => ({
-                ...prev,
-                ...context,
+              onNext={({
                 gender,
                 birthDate,
                 name,
-              }));
-            }}
+              }: { gender: string; birthDate: string; name: string }) => void
+                // 유저 정보 입력 후 소비 성향 체크 단계로 이동
+                funnel.history.push('소비성향체크', (prev) => ({
+                  ...prev,
+                  ...context,
+                  gender,
+                  birthDate,
+                  name,
+                }))
+              }
             />
           ),
         })}
@@ -95,7 +104,7 @@ const SignupPage = (): React.JSX.Element => {
             <Agreement
               onNext={() =>
                 funnel.history.push('소비성향결과', (prev) => ({
-                  ...(prev as SignupSteps['소비성향결과']),
+                  ...(prev as SignupSteps['소비성향결과']), // 타입 단언 추가
                   agreement: true,
                 }))
               }
@@ -103,30 +112,24 @@ const SignupPage = (): React.JSX.Element => {
           ),
         })}
         소비성향결과={funnel.Render.with({
-          render: ({ context }) => (
+          render: ( {context}) => (
             <ConsumptionResult
-              userName={context.name ?? '사용자'}
-              finalConsumptionType={
-                context.consumptionType
-                  ? CONSUMPTION_TYPE_LABEL_MAP[
-                      context.consumptionType as keyof typeof CONSUMPTION_TYPE_LABEL_MAP
-                    ]
-                  : ''
-              }
-              onNext={(consumptionType) =>
-                funnel.history.push('소비목적결과', (prev) => ({
-                  ...(prev as SignupSteps['소비목적결과']),
-                  consumptionType: consumptionType as ConsumptionType,
-                  consumptionGoal: '',
-                }))
-              }
-            />
+  userName={context.name ?? '사용자'}
+  finalConsumptionType={context.consumptionType ?? '균형형'} // 분석 결과값 전달
+  onNext={(consumptionType) =>
+    funnel.history.push('소비목적결과', (prev) => ({
+      ...(prev as SignupSteps['소비목적결과']),
+      consumptionType: consumptionType as ConsumptionType,
+      consumptionGoal: '',
+    }))
+  }
+/>
           ),
         })}
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
             <ConsumptionGoal
-              consumptionType={(context.consumptionType ?? 'CONSERVATIVE') as ConsumptionType}
+              consumptionType={context.consumptionType ?? '균형형'}
               onComplete={async (selectedGoal) => {
                 const signupData = {
                   email: context.email,

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -12,6 +12,7 @@ import ConsumptionResult from '@/components/signup/ConsumptionResult/Consumption
 import EmailForm from '@/components/signup/EmailForm/EmailForm';
 import InfoForm from '@/components/signup/InfoForm/InfoForm';
 import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
+import { ConsumptionType } from '@/constants/auth.constant';
 import { api } from '@/lib/axios';
 import { SignupSteps } from '@/types/funnel.type';
 
@@ -105,9 +106,10 @@ const SignupPage = (): React.JSX.Element => {
           render: ( {context}) => (
             <ConsumptionResult
               userName={context.name ?? '사용자'}
-              onNext={() =>
+              onNext={(consumptionType) =>
                 funnel.history.push('소비목적결과', (prev) => ({
                   ...(prev as SignupSteps['소비목적결과']), // 타입 단언 추가
+                  consumptionType: consumptionType as ConsumptionType,
                   consumptionGoal: '',
                 }))
               }
@@ -117,7 +119,7 @@ const SignupPage = (): React.JSX.Element => {
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
             <ConsumptionGoal
-              consumptionType={context.consumptionType}
+              consumptionType={context.consumptionType ?? '절약형'}
               onComplete={async (selectedGoal) => {
                 const signupData = {
                   email: context.email,
@@ -125,7 +127,7 @@ const SignupPage = (): React.JSX.Element => {
                   sex: context.gender,
                   name: context.name,
                   birthDate: context.birthDate,
-                  consumptionType: context.consumptionType,
+                  consumptionType: context.consumptionType ?? '절약형',
                   consumeGoal: selectedGoal,
                 };
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -63,7 +63,7 @@ const SignupPage = (): React.JSX.Element => {
           render: ({ context }) => (
             <InfoForm
               defaultValues={{
-                gender: context.gender as '남성' | '여성' | undefined,
+                gender: context.gender as 'MALE' | 'FEMALE',
                 // number 타입의 birthDate를 "YYYY-MM-DD" 문자열로 변환
                 birthDate:
                   typeof context.birthDate === 'number'
@@ -75,7 +75,7 @@ const SignupPage = (): React.JSX.Element => {
                 gender,
                 birthDate,
                 name,
-              }: { gender: string; birthDate: string; name: string }) =>
+              }: { gender: string; birthDate: string; name: string }) => void
                 // 유저 정보 입력 후 소비 성향 체크 단계로 이동
                 funnel.history.push('소비성향체크', (prev) => ({
                   ...prev,
@@ -92,9 +92,8 @@ const SignupPage = (): React.JSX.Element => {
           render: () => (
             <Agreement
               onNext={() =>
-                // 동의 완료 시 결과 단계로 이동
                 funnel.history.push('소비성향결과', (prev) => ({
-                  ...prev,
+                  ...(prev as SignupSteps['소비성향결과']), // 타입 단언 추가
                   agreement: true,
                 }))
               }
@@ -102,12 +101,12 @@ const SignupPage = (): React.JSX.Element => {
           ),
         })}
         소비성향결과={funnel.Render.with({
-          render: () => (
+          render: ( {context}) => (
             <ConsumptionResult
+              userName={context.name ?? '사용자'}
               onNext={() =>
-                // 결과 확인 후 소비 목적 단계로 이동
                 funnel.history.push('소비목적결과', (prev) => ({
-                  ...prev,
+                  ...(prev as SignupSteps['소비목적결과']), // 타입 단언 추가
                   consumptionGoal: '',
                 }))
               }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -116,8 +116,31 @@ const SignupPage = (): React.JSX.Element => {
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
             <ConsumptionGoal
-              // 최종 완료 시 회원가입 완료 로그 출력
-              onComplete={() => console.log('회원가입 완료', context)}
+              onComplete={async (selectedGoal) => {
+                const signupData = {
+                  ...context,
+                  consumptionGoal: selectedGoal,
+                };
+
+                try {
+                  // 🔥 실제 서버 요청 예시 (적절한 API로 교체)
+                  const response = await fetch('/api/signup', {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(signupData),
+                  });
+
+                  if (!response.ok) throw new Error('회원가입 실패');
+
+                  console.log('회원가입 완료', signupData);
+                  // 예: 홈으로 이동 또는 완료 페이지
+                } catch (error) {
+                  console.error('회원가입 에러:', error);
+                  // 사용자에게 에러 메시지 보여주기 등
+                }
+              }}
             />
           ),
         })}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -12,6 +12,7 @@ import ConsumptionResult from '@/components/signup/ConsumptionResult/Consumption
 import EmailForm from '@/components/signup/EmailForm/EmailForm';
 import InfoForm from '@/components/signup/InfoForm/InfoForm';
 import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
+import { api } from '@/lib/axios';
 import { SignupSteps } from '@/types/funnel.type';
 
 const SignupPage = (): React.JSX.Element => {
@@ -122,23 +123,15 @@ const SignupPage = (): React.JSX.Element => {
                   consumptionGoal: selectedGoal,
                 };
 
+                console.log('서버로 보내는 회원가입 데이터:', signupData);
+
                 try {
-                  // 🔥 실제 서버 요청 예시 (적절한 API로 교체)
-                  const response = await fetch('/api/signup', {
-                    method: 'POST',
-                    headers: {
-                      'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify(signupData),
-                  });
-
-                  if (!response.ok) throw new Error('회원가입 실패');
-
-                  console.log('회원가입 완료', signupData);
-                  // 예: 홈으로 이동 또는 완료 페이지
+                  const response = await api.post('/api/auth/signup/password', signupData);
+                  console.log('회원가입 완료', response.data);
+                  // 회원가입 성공 후 리다이렉트 또는 상태 업데이트
                 } catch (error) {
                   console.error('회원가입 에러:', error);
-                  // 사용자에게 에러 메시지 보여주기 등
+                  // 에러 처리 UI 로직
                 }
               }}
             />

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -4,6 +4,11 @@ import React from 'react';
 
 import { useFunnel } from '@use-funnel/browser';
 
+
+function reverseMap<T extends Record<string, string>>(map: T, value: string): keyof T | undefined {
+  return (Object.entries(map).find(([, v]) => v === value)?.[0]) as keyof T | undefined;
+}
+
 import Header from '@/components/Header/Header';
 import { Wrapper } from '@/components/loanApplicationFunnel/LoanApplicationFunnel.style';
 import Agreement from '@/components/signup/AgreeForConsumptionType/AgreeForConsumptionType';
@@ -13,6 +18,9 @@ import EmailForm from '@/components/signup/EmailForm/EmailForm';
 import InfoForm from '@/components/signup/InfoForm/InfoForm';
 import PasswordForm from '@/components/signup/PasswordForm/PasswordForm';
 import { ConsumptionType } from '@/constants/auth.constant';
+import {
+  CONSUME_GOAL_LABEL_MAP,
+} from '@/constants/customer.constant';
 import { api } from '@/lib/axios';
 import { SignupSteps } from '@/types/funnel.type';
 
@@ -119,7 +127,7 @@ const SignupPage = (): React.JSX.Element => {
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
             <ConsumptionGoal
-              consumptionType={context.consumptionType ?? '절약형'}
+              consumptionType={context.consumptionType ?? '균형형'}
               onComplete={async (selectedGoal) => {
                 const signupData = {
                   email: context.email,
@@ -127,8 +135,8 @@ const SignupPage = (): React.JSX.Element => {
                   sex: context.gender,
                   name: context.name,
                   birthDate: context.birthDate,
-                  consumptionType: context.consumptionType ?? '절약형',
-                  consumeGoal: selectedGoal,
+                  consumptionType: context.consumptionType ?? 'CONSERVATIVE',
+                  consumeGoal: reverseMap(CONSUME_GOAL_LABEL_MAP, selectedGoal),
                 };
 
                 console.log('서버로 보내는 회원가입 데이터:', signupData);
@@ -136,10 +144,10 @@ const SignupPage = (): React.JSX.Element => {
                 try {
                   const response = await api.post('/api/auth/signup/password', signupData);
                   console.log('회원가입 완료', response.data);
-                  // 성공 후 리다이렉트 혹은 상태 변경 로직 추가
+                  // 성공 처리 로직 추가
                 } catch (error) {
                   console.error('회원가입 에러:', error);
-                  // 에러 UI 처리 추가
+                  // 에러 UI 처리
                 }
               }}
             />

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -28,6 +28,7 @@ const SignupPage = (): React.JSX.Element => {
           render: () => (
             <EmailForm
               onNext={(email) =>
+                // 이메일 입력 후 비밀번호 설정 단계로 이동
                 funnel.history.push('비밀번호설정', (prev) => ({ ...prev, email }))
               }
             />
@@ -40,6 +41,7 @@ const SignupPage = (): React.JSX.Element => {
               onNext={({ password, method }) => {
                 const nextStep =
                   method === '간편비밀번호' ? '간편비밀번호설정' : '내정보입력';
+                // 비밀번호 설정 후 선택된 방법에 따라 다음 단계로 이동
                 funnel.history.push(nextStep, (prev) => ({
                   ...prev,
                   ...context,
@@ -62,12 +64,19 @@ const SignupPage = (): React.JSX.Element => {
             <InfoForm
               defaultValues={{
                 gender: context.gender as '남성' | '여성' | undefined,
-                birthDate: context.birthDate
-                  ? Number(context.birthDate)
-                  : undefined,
-                name: context.name,
+                // number 타입의 birthDate를 "YYYY-MM-DD" 문자열로 변환
+                birthDate:
+                  typeof context.birthDate === 'number'
+                    ? new Date(context.birthDate).toISOString().slice(0, 10)
+                    : context.birthDate ?? '',
+                name: context.name ?? '',
               }}
-              onNext={({ gender, birthDate, name }: { gender: string; birthDate: number; name: string }) =>
+              onNext={({
+                gender,
+                birthDate,
+                name,
+              }: { gender: string; birthDate: string; name: string }) =>
+                // 유저 정보 입력 후 소비 성향 체크 단계로 이동
                 funnel.history.push('소비성향체크', (prev) => ({
                   ...prev,
                   ...context,
@@ -83,6 +92,7 @@ const SignupPage = (): React.JSX.Element => {
           render: () => (
             <Agreement
               onNext={() =>
+                // 동의 완료 시 결과 단계로 이동
                 funnel.history.push('소비성향결과', (prev) => ({
                   ...prev,
                   agreement: true,
@@ -95,6 +105,7 @@ const SignupPage = (): React.JSX.Element => {
           render: () => (
             <ConsumptionResult
               onNext={() =>
+                // 결과 확인 후 소비 목적 단계로 이동
                 funnel.history.push('소비목적결과', (prev) => ({
                   ...prev,
                   consumptionGoal: '',
@@ -106,6 +117,7 @@ const SignupPage = (): React.JSX.Element => {
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
             <ConsumptionGoal
+              // 최종 완료 시 회원가입 완료 로그 출력
               onComplete={() => console.log('회원가입 완료', context)}
             />
           ),

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -117,6 +117,7 @@ const SignupPage = (): React.JSX.Element => {
         소비목적결과={funnel.Render.with({
           render: ({ context }) => (
             <ConsumptionGoal
+              consumptionType={context.consumptionType}
               onComplete={async (selectedGoal) => {
                 const signupData = {
                   email: context.email,
@@ -124,7 +125,7 @@ const SignupPage = (): React.JSX.Element => {
                   sex: context.gender,
                   name: context.name,
                   birthDate: context.birthDate,
-                  consumptionType: context.cosumptionType,
+                  consumptionType: context.consumptionType,
                   consumeGoal: selectedGoal,
                 };
 
@@ -133,10 +134,10 @@ const SignupPage = (): React.JSX.Element => {
                 try {
                   const response = await api.post('/api/auth/signup/password', signupData);
                   console.log('회원가입 완료', response.data);
-                  // 회원가입 성공 후 리다이렉트 또는 상태 업데이트
+                  // 성공 후 리다이렉트 혹은 상태 변경 로직 추가
                 } catch (error) {
                   console.error('회원가입 에러:', error);
-                  // 에러 처리 UI 로직
+                  // 에러 UI 처리 추가
                 }
               }}
             />

--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const Wrapper = styled.label<{ disabled: boolean; size: string }>`
   display: inline-flex;

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import styled from '@emotion/styled';
+import Image from 'next/image';
+
 import { ImageLabelContainer, Label, ShowMore, Wrapper } from './CheckBox.style';
 
 interface SvgCheckboxProps {

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+
 import { ProgressBarBackground, ProgressBarContainer, ProgressBarFill } from './ProgressBar.style';
 
 interface ProgressBarProps {

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -3,8 +3,9 @@
 import styled from '@emotion/styled';
 
 import { semanticColor } from '@/styles/colors';
-import { InputType } from './TextField.type';
 import { typoStyleMap } from '@/styles/typos';
+
+import { InputType } from './TextField.type';
 
 const getBorderColor = (type: InputType = 'ACTIVE') => {
   switch (type) {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,12 +1,14 @@
 'use client';
 import React, { useState } from 'react';
-import { TextFieldContext } from './TextFieldContext';
-import { TextFieldProps } from './TextField.type';
-import * as S from './TextField.style';
-import { useTextFieldContext } from './TextFieldContext';
-import { getInputType } from '@/lib/getInputType';
-import ErrorIcon from '@/assets/icons/error_18.svg';
+
 import DeleteIcon from '@/assets/icons/delete_24.svg';
+import ErrorIcon from '@/assets/icons/error_18.svg';
+import { getInputType } from '@/lib/getInputType';
+
+import * as S from './TextField.style';
+import { TextFieldProps } from './TextField.type';
+import { TextFieldContext , useTextFieldContext } from './TextFieldContext';
+
 
 const TextFieldComponent = ({
   children,

--- a/src/components/loanApplicationFunnel/LoanApplicationFunnel.tsx
+++ b/src/components/loanApplicationFunnel/LoanApplicationFunnel.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useFunnel } from '@use-funnel/browser';
-import { JobStep } from './JobStep/JobStep';
-import { CreditStep } from './CreditStep/CreditStep';
-import { PurposeStep } from './PurposeStep/PurposeStep';
+import { useRouter } from 'next/navigation';
+
+import Header from '../Header/Header';
 import ProgressBar from '../ProgressBar/ProgressBar';
-import ReviewResultAndLoanApplication from './ReviewResultAndLoanApplication/ReviewResultAndLoanApplication';
+
+import { CreditStep } from './CreditStep/CreditStep';
+import { JobStep } from './JobStep/JobStep';
 import {
   Container,
   Description,
@@ -15,8 +17,10 @@ import {
   Title,
   Wrapper,
 } from './LoanApplicationFunnel.style';
-import Header from '../Header/Header';
-import { useRouter } from 'next/navigation';
+import { PurposeStep } from './PurposeStep/PurposeStep';
+import ReviewResultAndLoanApplication from './ReviewResultAndLoanApplication/ReviewResultAndLoanApplication';
+
+
 
 export type FunnelContextMap = {
   직업정보입력: {

--- a/src/components/login/LoginForm/LoginForm.tsx
+++ b/src/components/login/LoginForm/LoginForm.tsx
@@ -1,15 +1,21 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+
 import { zodResolver } from '@hookform/resolvers/zod';
-import { authSchemas } from '@/schemas/auth.schema';
-import { Container, Title } from '../LoginSelector/LoginSelector.style';
-import TextField from '@/components/TextField/TextField';
-import Button from '@/components/Button/Button';
-import { BtnContainer, FormContainer } from './LoginForm.style';
 import { motion } from 'framer-motion';
-import { z } from 'zod';
 import { useRouter } from 'next/navigation';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import Button from '@/components/Button/Button';
+import TextField from '@/components/TextField/TextField';
+import { authSchemas } from '@/schemas/auth.schema';
+
+import { Container, Title } from '../LoginSelector/LoginSelector.style';
+
+
+import { BtnContainer, FormContainer } from './LoginForm.style';
+
 
 type LoginFormValues = z.infer<typeof authSchemas.login>;
 

--- a/src/components/login/LoginSelector/LoginSelector.style.ts
+++ b/src/components/login/LoginSelector/LoginSelector.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const Container = styled.div`
   width: 100%;

--- a/src/components/login/LoginSelector/LoginSelector.tsx
+++ b/src/components/login/LoginSelector/LoginSelector.tsx
@@ -1,5 +1,10 @@
 'use client';
 import React from 'react';
+
+import Image from 'next/image';
+
+import BottomSheet from '@/components/BottomSheet/BottomSheet';
+
 import {
   BtnContainer,
   BtnWrapper,
@@ -8,8 +13,6 @@ import {
   SheetBtn,
   Title,
 } from './LoginSelector.style';
-import BottomSheet from '@/components/BottomSheet/BottomSheet';
-import Image from 'next/image';
 
 export type LoginSelectorProps = {
   onSelectPassword: () => void;

--- a/src/components/signup/AgreeForConsumptionType/AgreeForConsumptionType.tsx
+++ b/src/components/signup/AgreeForConsumptionType/AgreeForConsumptionType.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import CheckBox from '@/components/CheckBox/CheckBox';
 import styled from '@emotion/styled';
-import { authSchemas } from '@/schemas/auth.schema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+
 import Button from '@/components/Button/Button';
+import CheckBox from '@/components/CheckBox/CheckBox';
+import { authSchemas } from '@/schemas/auth.schema';
+
+
+
 import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
 
 type FormData = z.infer<typeof authSchemas.agreement>;

--- a/src/components/signup/AgreeForConsumptionType/AgreeForConsumptionType.tsx
+++ b/src/components/signup/AgreeForConsumptionType/AgreeForConsumptionType.tsx
@@ -44,6 +44,7 @@ const Agreement = ({ onNext }: AgreementProps) => {
   };
 
   const onSubmit = (data: FormData) => {
+    console.log('제출된 동의 정보:', data);
     onNext();
   };
 
@@ -67,6 +68,11 @@ const Agreement = ({ onNext }: AgreementProps) => {
               checked={agreePrivacy}
               onChange={(val) => setValue('agreePrivacy', val, { shouldValidate: true })}
             />
+
+            {errors.agreePrivacy && (
+              <ErrorMessage>{errors.agreePrivacy.message}</ErrorMessage>
+            )}
+
 
             <CheckBox
               size="small"
@@ -100,4 +106,11 @@ const CheckBoxContainer = styled.div`
   border-top: 1px solid #ddd;
   padding-top: 16px;
   gap: 22px;
+`;
+
+const ErrorMessage = styled.p`
+  color: red;
+  font-size: 12px;
+  margin-top: 4px;
+  margin-left: 8px;
 `;

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.style.ts
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const Options = styled.div`
   display: flex;

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -22,9 +22,8 @@ interface ConsumptionGoalProps {
   onComplete: (selectedGoal: string) => void;
 }
 
-const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
-  const selectedType: ConsumptionType = '절약형';
-  // const selectedType = consumptionType;  // 하드코딩 제거, props 값 사용
+const ConsumptionGoal = ({ consumptionType, onComplete }: ConsumptionGoalProps) => {
+  const selectedType = consumptionType;
   const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
 
   const { options } = consumptionGoalMap[selectedType];
@@ -35,7 +34,7 @@ const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
       <CharacterContainer>
         <ResultCard>
           <Image src={'/icons/webeeSaving_120.svg'} alt="최종 캐릭터" width={120} height={120} />
-          <Tag>절약형</Tag>
+          <Tag>{selectedType}</Tag>
           <Description>필요한 것만 소비하는 편이에요</Description>
         </ResultCard>
 

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -18,7 +18,7 @@ import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
 import { GoalOptionButton, Options } from './ConsumptionGoal.style';
 
 interface ConsumptionGoalProps {
-  onComplete: () => void;
+  onComplete: (selectedGoal: string) => void;
 }
 
 const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
@@ -56,7 +56,7 @@ const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
             disabled={!selectedGoal}
             onClick={() => {
               if (selectedGoal) {
-                onComplete();
+                onComplete(selectedGoal);
               }
             }}
           />

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -18,16 +18,16 @@ import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
 import { GoalOptionButton, Options } from './ConsumptionGoal.style';
 
 interface ConsumptionGoalProps {
-  // consumptionType: ConsumptionType;
+  consumptionType: ConsumptionType;
   onComplete: (selectedGoal: string) => void;
 }
 
-const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
-  const selectedType: ConsumptionType = '절약형';
+const ConsumptionGoal = ({ consumptionType ,onComplete }: ConsumptionGoalProps) => {
+  // const selectedType: ConsumptionType = '절약형';
   // const selectedType = consumptionType;  // 하드코딩 제거, props 값 사용
   const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
 
-  const { options } = consumptionGoalMap[selectedType];
+  const { options } = consumptionGoalMap[consumptionType];
 
   return (
     <Container>

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -1,23 +1,27 @@
 'use client';
 
+import { useState } from 'react';
+
 import Image from 'next/image';
+
 import Button from '@/components/Button/Button';
-import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
-import { GoalOptionButton, Options } from './ConsumptionGoal.style';
+import { consumptionGoalMap, ConsumptionType } from '@/constants/auth.constant';
+
 import {
   CharacterContainer,
   Description,
   ResultCard,
   Tag,
 } from '../ConsumptionResult/ConsumptionResult.style';
-import { consumptionGoalMap, ConsumptionType } from '@/constants/auth.constant';
-import { useState } from 'react';
+import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
+
+import { GoalOptionButton, Options } from './ConsumptionGoal.style';
 
 interface ConsumptionGoalProps {
   onComplete: () => void;
 }
 
-export default function ConsumptionGoal({ onComplete }: ConsumptionGoalProps) {
+const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
   const selectedType: ConsumptionType = '절약형';
   const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
 
@@ -60,4 +64,6 @@ export default function ConsumptionGoal({ onComplete }: ConsumptionGoalProps) {
       </CharacterContainer>
     </Container>
   );
-}
+};
+
+export default ConsumptionGoal;

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -22,12 +22,12 @@ interface ConsumptionGoalProps {
   onComplete: (selectedGoal: string) => void;
 }
 
-const ConsumptionGoal = ({ consumptionType ,onComplete }: ConsumptionGoalProps) => {
-  // const selectedType: ConsumptionType = '절약형';
+const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
+  const selectedType: ConsumptionType = '절약형';
   // const selectedType = consumptionType;  // 하드코딩 제거, props 값 사용
   const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
 
-  const { options } = consumptionGoalMap[consumptionType];
+  const { options } = consumptionGoalMap[selectedType];
 
   return (
     <Container>

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -18,11 +18,13 @@ import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
 import { GoalOptionButton, Options } from './ConsumptionGoal.style';
 
 interface ConsumptionGoalProps {
+  consumptionType: ConsumptionType;
   onComplete: (selectedGoal: string) => void;
 }
 
 const ConsumptionGoal = ({ onComplete }: ConsumptionGoalProps) => {
   const selectedType: ConsumptionType = '절약형';
+  // const selectedType = consumptionType;  // 하드코딩 제거, props 값 사용
   const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
 
   const { options } = consumptionGoalMap[selectedType];

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -18,11 +18,11 @@ import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
 import { GoalOptionButton, Options } from './ConsumptionGoal.style';
 
 interface ConsumptionGoalProps {
-  consumptionType: ConsumptionType;
+  consumptionType?: ConsumptionType;
   onComplete: (selectedGoal: string) => void;
 }
 
-const ConsumptionGoal = ({ consumptionType, onComplete }: ConsumptionGoalProps) => {
+const ConsumptionGoal = ({ consumptionType = '균형형', onComplete }: ConsumptionGoalProps) => {
   const selectedType = consumptionType;
   const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
 

--- a/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
+++ b/src/components/signup/ConsumptionGoal/ConsumptionGoal.tsx
@@ -18,7 +18,7 @@ import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
 import { GoalOptionButton, Options } from './ConsumptionGoal.style';
 
 interface ConsumptionGoalProps {
-  consumptionType: ConsumptionType;
+  // consumptionType: ConsumptionType;
   onComplete: (selectedGoal: string) => void;
 }
 

--- a/src/components/signup/ConsumptionResult/ConsumptionResult.style.ts
+++ b/src/components/signup/ConsumptionResult/ConsumptionResult.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const CharacterContainer = styled.div`
   margin-top: 20px;

--- a/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
+++ b/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
-import Button from '@/components/Button/Button';
-import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
-import { CharacterContainer, Description, ResultCard, Tag } from './ConsumptionResult.style';
+
 import { motion } from 'framer-motion';
+import Image from 'next/image';
+
+import Button from '@/components/Button/Button';
+
+import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
+
+import { CharacterContainer, Description, ResultCard, Tag } from './ConsumptionResult.style';
 
 const characterList = [
   {
@@ -26,7 +30,7 @@ interface ConsumptionResultProps {
   onNext: () => void;
 }
 
-export default function ConsumptionResult({ onNext }: ConsumptionResultProps) {
+const ConsumptionResult = ({ onNext }: ConsumptionResultProps) => {
   const [loading, setLoading] = useState(true);
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -80,4 +84,6 @@ export default function ConsumptionResult({ onNext }: ConsumptionResultProps) {
       </CharacterContainer>
     </Container>
   );
-}
+};
+
+export default ConsumptionResult;

--- a/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
+++ b/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
@@ -28,9 +28,10 @@ const characterList = [
 
 interface ConsumptionResultProps {
   onNext: () => void;
+  userName: string;
 }
 
-const ConsumptionResult = ({ onNext }: ConsumptionResultProps) => {
+const ConsumptionResult = ({ onNext, userName }: ConsumptionResultProps) => {
   const [loading, setLoading] = useState(true);
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -52,7 +53,7 @@ const ConsumptionResult = ({ onNext }: ConsumptionResultProps) => {
 
   return (
     <Container>
-      <Title>서채연님의 소비 성향은...</Title>
+      <Title>{userName}님의 소비 성향은...</Title>
       <CharacterContainer>
         {loading ? (
           <ResultCard>

--- a/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
+++ b/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
@@ -29,11 +29,16 @@ const characterList = [
 interface ConsumptionResultProps {
   onNext: (consumptionType: string) => void;
   userName: string;
+  finalConsumptionType: string;
 }
 
-const ConsumptionResult = ({ onNext, userName }: ConsumptionResultProps) => {
+const ConsumptionResult = ({ onNext, userName, finalConsumptionType }: ConsumptionResultProps) => {
   const [loading, setLoading] = useState(true);
   const [currentIndex, setCurrentIndex] = useState(0);
+
+  // finalIndex를 상태로 관리하지 않고, loading이 false일 때 계산
+  const finalIndex =
+    characterList.findIndex((char) => char.key === finalConsumptionType) ?? 0;
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -49,7 +54,7 @@ const ConsumptionResult = ({ onNext, userName }: ConsumptionResultProps) => {
       clearTimeout(timeout);
       clearInterval(interval);
     };
-  }, []);
+  }, [finalConsumptionType]);
 
   return (
     <Container>
@@ -71,15 +76,15 @@ const ConsumptionResult = ({ onNext, userName }: ConsumptionResultProps) => {
             transition={{ duration: 0.5 }}
           >
             <ResultCard>
-              <Image src={characterList[0].src} alt="최종 캐릭터" width={120} height={120} />
-              <Tag>{characterList[0].key}</Tag>
-              <Description>{characterList[0].description}</Description>
+              <Image src={characterList[finalIndex].src} alt="최종 캐릭터" width={120} height={120} />
+              <Tag>{characterList[finalIndex].key}</Tag>
+              <Description>{characterList[finalIndex].description}</Description>
             </ResultCard>
           </motion.div>
         )}
         {!loading && (
           <BtnContainer>
-            <Button text="다음으로" size="XL" onClick={() => onNext(characterList[0].key)} />
+            <Button text="다음으로" size="XL" onClick={() => onNext(characterList[finalIndex].key)} />
           </BtnContainer>
         )}
       </CharacterContainer>

--- a/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
+++ b/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
@@ -29,10 +29,10 @@ const characterList = [
 interface ConsumptionResultProps {
   onNext: (consumptionType: string) => void;
   userName: string;
-  finalConsumptionType: string;
+  finalConsumptionType?: string;
 }
 
-const ConsumptionResult = ({ onNext, userName, finalConsumptionType }: ConsumptionResultProps) => {
+const ConsumptionResult = ({ onNext, userName, finalConsumptionType = '균형형' }: ConsumptionResultProps) => {
   const [loading, setLoading] = useState(true);
   const [currentIndex, setCurrentIndex] = useState(0);
 

--- a/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
+++ b/src/components/signup/ConsumptionResult/ConsumptionResult.tsx
@@ -27,7 +27,7 @@ const characterList = [
 ];
 
 interface ConsumptionResultProps {
-  onNext: () => void;
+  onNext: (consumptionType: string) => void;
   userName: string;
 }
 
@@ -79,7 +79,7 @@ const ConsumptionResult = ({ onNext, userName }: ConsumptionResultProps) => {
         )}
         {!loading && (
           <BtnContainer>
-            <Button text="다음으로" size="XL" onClick={onNext} />
+            <Button text="다음으로" size="XL" onClick={() => onNext(characterList[0].key)} />
           </BtnContainer>
         )}
       </CharacterContainer>

--- a/src/components/signup/EmailForm/EmailForm.style.ts
+++ b/src/components/signup/EmailForm/EmailForm.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const Container = styled.div`
   width: 100%;

--- a/src/components/signup/EmailForm/EmailForm.tsx
+++ b/src/components/signup/EmailForm/EmailForm.tsx
@@ -1,25 +1,26 @@
 'use client';
 
-import Button from '@/components/Button/Button';
-import { BtnContainer, Container, FormContainer, Title } from './EmailForm.style';
-import { authSchemas } from '@/schemas/auth.schema';
-import { z } from 'zod';
 import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+
 import { zodResolver } from '@hookform/resolvers/zod';
-import TextField from '@/components/TextField/TextField';
 import { motion } from 'framer-motion';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { sendEmailVerificationCode, verifyEmailCode } from '@/apis/auth';
+import Button from '@/components/Button/Button';
+import TextField from '@/components/TextField/TextField';
+import { authSchemas } from '@/schemas/auth.schema';
+
+import { BtnContainer, Container, FormContainer, Title } from './EmailForm.style';
 
 type FormData = z.infer<typeof authSchemas.emailWithCode>;
 
-// 백엔드 API 서버 주소 (포트 포함)
-const BASE_URL = 'http://localhost:8080';
+const EmailForm = ({ onNext }: { onNext: (email: string) => void }) => {
+  const [codeSent, setCodeSent] = useState(false); // 인증 코드 요청 여부
 
-export default function EmailForm({ onNext }: { onNext: (email: string) => void }) {
-  const [codeSent, setCodeSent] = useState(false);
   const {
     control,
-    handleSubmit,
     watch,
     trigger,
     formState: { errors, dirtyFields },
@@ -35,68 +36,33 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
   const email = watch('email');
   const code = watch('code');
 
+  // 인증 코드 요청 핸들러
   const handleRequestCode = async () => {
     const isEmailValid = await trigger('email');
     if (!isEmailValid) return;
-    setCodeSent(true);
+
+    try {
+      await sendEmailVerificationCode({ email });
+      setCodeSent(true); // 코드 입력 UI 표시
+    } catch (error) {
+      console.error(error);
+      alert('인증메일 발송에 실패했습니다.');
+    }
   };
 
+  // 인증 확인 핸들러
   const handleVerify = async () => {
     const isCodeValid = await trigger('code');
     if (!isCodeValid) return;
-    onNext(email);
+
+    try {
+      await verifyEmailCode({ email, code });
+      onNext(email); // 인증 성공 시 다음 단계로 이동
+    } catch (error) {
+      console.error(error);
+      alert('인증번호가 틀렸거나 만료되었습니다.');
+    }
   };
-
-  // // 인증메일 요청 핸들러
-  // const handleRequestCode = async () => {
-  //   console.log('handleRequestCode called, email:', email);
-  //   const isEmailValid = await trigger('email');
-  //   if (!isEmailValid) {
-  //     console.log('Email validation failed');
-  //     return;
-  //   }
-  //   try {
-  //   const res = await fetch('http://localhost:8080/api/auth/email', {
-  //     method: 'POST',
-  //     headers: { 'Content-Type': 'application/json' },
-  //     body: JSON.stringify({ email }),
-  //     mode: 'cors', // 추가
-  //   });
-  //   console.log('Fetch response status:', res.status);
-  //   if (!res.ok) throw new Error(`서버 응답 에러: ${res.status}`);
-  //   setCodeSent(true);
-  //   } catch (error) {
-  //     if (error instanceof Error) {
-  //       console.error('Fetch error:', error.message);
-  //     } else {
-  //       console.error('Fetch error (non-Error):', error);
-  //     }
-  //     alert('인증메일 발송에 실패했습니다.');
-  //   }
-  // };
-
-  // const handleVerify = async () => {
-  //   const isCodeValid = await trigger('code');
-  //   if (!isCodeValid) return;
-
-  //   try {
-  //     const response = await fetch('http://localhost:8080/api/auth/email/verification', {
-  //       method: 'POST',
-  //       headers: { 'Content-Type': 'application/json' },
-  //       body: JSON.stringify({ email, code }),
-  //     });
-
-  //     if (!response.ok) {
-  //       const errorText = await response.text();
-  //       throw new Error(`인증번호 검증 실패: ${response.status} - ${errorText}`);
-  //     }
-
-  //     onNext(email);
-  //   } catch (error) {
-  //     console.error(error);
-  //     alert('인증번호가 틀렸거나 만료되었습니다.');
-  //   }
-  // };
 
   return (
     <Container>
@@ -107,6 +73,7 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
       </Title>
 
       <FormContainer>
+        {/* 인증번호 입력 영역 (코드 요청 후 노출) */}
         {codeSent && (
           <motion.div
             initial={{ y: -40, opacity: 0 }}
@@ -121,10 +88,7 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
                   value={field.value}
                   onChange={field.onChange}
                   isError={!!errors.code}
-                  rightContent={{
-                    type: 'DELETE',
-                    onClick: () => field.onChange(''),
-                  }}
+                  rightContent={{ type: 'DELETE', onClick: () => field.onChange('') }}
                 >
                   <TextField.TextFieldBox type="text" placeholder="인증번호 입력" />
                   <TextField.ErrorText message={errors.code?.message ?? ''} />
@@ -134,6 +98,7 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
           </motion.div>
         )}
 
+        {/* 이메일 입력 필드 */}
         <Controller
           name="email"
           control={control}
@@ -142,10 +107,7 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
               value={field.value}
               onChange={field.onChange}
               isError={!!errors.email}
-              rightContent={{
-                type: 'DELETE',
-                onClick: () => field.onChange(''),
-              }}
+              rightContent={{ type: 'DELETE', onClick: () => field.onChange('') }}
             >
               <TextField.TextFieldBox type="email" placeholder="이메일 주소 입력" />
               <TextField.ErrorText message={errors.email?.message ?? ''} />
@@ -154,6 +116,7 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
         />
 
         <BtnContainer>
+          {/* 인증 요청/확인 버튼 */}
           {!codeSent ? (
             <Button
               type="button"
@@ -173,4 +136,6 @@ export default function EmailForm({ onNext }: { onNext: (email: string) => void 
       </FormContainer>
     </Container>
   );
-}
+};
+
+export default EmailForm;

--- a/src/components/signup/InfoForm/InfoForm.tsx
+++ b/src/components/signup/InfoForm/InfoForm.tsx
@@ -1,158 +1,139 @@
-'use client';
+'use client'
 
-import Button from '@/components/Button/Button';
-import TextField from '@/components/TextField/TextField';
-import { BtnContainer, Container, Title } from '../EmailForm/EmailForm.style';
-import styled from '@emotion/styled';
-import { useForm, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { motion } from 'framer-motion';
-import { authSchemas } from '@/schemas/auth.schema';
+import React from 'react'
 
-type FormData = z.infer<typeof authSchemas.infoRegister>;
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Controller, useForm } from 'react-hook-form'
+import { z } from 'zod'
 
-interface InfoFormProps {
-  defaultValues?: Partial<FormData>;
-  onNext: (data: FormData) => void;
+import Button from '@/components/Button/Button'
+import TextField from '@/components/TextField/TextField'
+
+import { Container, Title, FormContainer, BtnContainer } from './InfoFrom.style'
+
+export type LoginSelectorProps = {
+  onNext: (info: { gender: string; birthDate: string; name: string }) => void
 }
 
-export const InfoForm = ({ defaultValues, onNext }: InfoFormProps) => {
+const schema = z.object({
+  name: z.string().min(1, '이름을 입력해주세요.'),
+  gender: z.enum(['MALE', 'FEMALE'], { required_error: '성별을 선택해주세요.' }),
+  birthDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '생년월일 형식이 올바르지 않습니다.'),
+})
+
+type FormData = z.infer<typeof schema>
+
+const InfoForm = ({ onNext }: LoginSelectorProps) => {
   const {
     control,
     handleSubmit,
-    watch,
     formState: { errors, isValid },
   } = useForm<FormData>({
-    resolver: zodResolver(authSchemas.infoRegister),
+    resolver: zodResolver(schema),
     mode: 'onChange',
     defaultValues: {
-      gender: defaultValues?.gender ?? undefined,
-      birthDate: defaultValues?.birthDate,
-      name: defaultValues?.name,
+      name: '',
+      gender: 'FEMALE',
+      birthDate: '',
     },
-  });
+  })
 
-  const gender = watch('gender');
-  const birthDate = watch('birthDate');
-
-  const currentStep: 'gender' | 'birthDate' | 'name' = !gender
-    ? 'gender'
-    : !birthDate || birthDate.toString().length !== 8
-    ? 'birthDate'
-    : 'name';
-
-  const getTitle = () => {
-    console.log(currentStep);
-    switch (currentStep) {
-      case 'gender':
-        return '성별을 알려주세요';
-      case 'birthDate':
-        return '생년월일을 알려주세요';
-      case 'name':
-        return '이름을 알려주세요';
-    }
-  };
+  const onSubmit = (data: FormData) => {
+    onNext(data)
+  }
 
   return (
     <Container>
-      <Title>{getTitle()}</Title>
-      <Wrapper>
-        {currentStep === 'name' && (
-          <motion.div
-            initial={{ y: -20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ duration: 0.3 }}
-          >
-            <Controller
-              name="name"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  value={field.value}
-                  onChange={field.onChange}
-                  isError={!!errors.name}
-                  rightContent={{ type: 'DELETE', onClick: () => field.onChange('') }}
-                >
-                  <TextField.TextFieldBox type="text" placeholder="이름 입력" />
-                  <TextField.ErrorText message={errors.name?.message ?? ''} />
-                </TextField>
-              )}
-            />
-          </motion.div>
+      <Title>
+        반가워요!
+        <br />
+        개인 정보를 입력해 주세요
+      </Title>
+
+      <FormContainer onSubmit={handleSubmit(onSubmit)}>
+        {/* 이름 입력 */}
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <TextField value={field.value} onChange={field.onChange} isError={!!errors.name}>
+              <TextField.TextFieldBox placeholder="이름 입력" />
+              <TextField.ErrorText message={errors.name?.message ?? ''} />
+            </TextField>
+          )}
+        />
+
+        {/* 성별 선택 버튼 */}
+        <Controller
+          name="gender"
+          control={control}
+          render={({ field }) => (
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => field.onChange('FEMALE')}
+                style={{
+                  flex: 1,
+                  padding: '12px 0',
+                  borderRadius: 8,
+                  border: '1.5px solid',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  backgroundColor: field.value === 'FEMALE' ? '#3B82F6' : '#FFF',
+                  color: field.value === 'FEMALE' ? '#FFF' : '#222',
+                  borderColor: field.value === 'FEMALE' ? '#3B82F6' : '#D1D5DB',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease-in-out',
+                }}
+              >
+                여성
+              </button>
+              <button
+                type="button"
+                onClick={() => field.onChange('MALE')}
+                style={{
+                  flex: 1,
+                  padding: '12px 0',
+                  borderRadius: 8,
+                  border: '1.5px solid',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  backgroundColor: field.value === 'MALE' ? '#3B82F6' : '#FFF',
+                  color: field.value === 'MALE' ? '#FFF' : '#222',
+                  borderColor: field.value === 'MALE' ? '#3B82F6' : '#D1D5DB',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease-in-out',
+                }}
+              >
+                남성
+              </button>
+            </div>
+          )}
+        />
+        {errors.gender && (
+          <p style={{ color: '#EF4444', fontSize: 12, marginTop: 4 }}>{errors.gender.message}</p>
         )}
 
-        {gender && (
-          <motion.div
-            initial={{ y: -20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ duration: 0.3 }}
-          >
-            <Controller
-              name="birthDate"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  value={field.value}
-                  onChange={field.onChange}
-                  isError={!!errors.birthDate}
-                  rightContent={{ type: 'DELETE', onClick: () => field.onChange('') }}
-                >
-                  <TextField.TextFieldBox type="number" placeholder="생년월일 (예: 19990101)" />
-                  <TextField.ErrorText message={errors.birthDate?.message ?? ''} />
-                </TextField>
-              )}
-            />
-          </motion.div>
-        )}
-
-        <FlexContainer>
-          <Controller
-            name="gender"
-            control={control}
-            render={({ field }) => (
-              <>
-                <Button
-                  size="M"
-                  text="여성"
-                  varient="TERTIARY"
-                  selected={field.value === '여성'}
-                  onClick={() => field.onChange('여성')}
-                />
-                <Button
-                  size="M"
-                  text="남성"
-                  varient="TERTIARY"
-                  selected={field.value === '남성'}
-                  onClick={() => field.onChange('남성')}
-                />
-              </>
-            )}
-          />
-        </FlexContainer>
+        {/* 생년월일 입력 */}
+        <Controller
+          name="birthDate"
+          control={control}
+          render={({ field }) => (
+            <TextField value={field.value} onChange={field.onChange} isError={!!errors.birthDate}>
+              <TextField.TextFieldBox type="date" placeholder="생년월일 (YYYY-MM-DD)" />
+              <TextField.ErrorText message={errors.birthDate?.message ?? ''} />
+            </TextField>
+          )}
+        />
 
         <BtnContainer>
-          <Button
-            type="submit"
-            text="다음으로"
-            disabled={!isValid}
-            onClick={handleSubmit(onNext)}
-          />
+          <Button type="submit" text="다음" disabled={!isValid} />
         </BtnContainer>
-      </Wrapper>
+      </FormContainer>
     </Container>
-  );
-};
+  )
+}
 
-const Wrapper = styled.div`
-  padding: 0px 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-`;
-
-const FlexContainer = styled.div`
-  width: 100%;
-  display: flex;
-  gap: 8px;
-`;
+export default InfoForm

--- a/src/components/signup/InfoForm/InfoForm.tsx
+++ b/src/components/signup/InfoForm/InfoForm.tsx
@@ -12,8 +12,14 @@ import TextField from '@/components/TextField/TextField'
 import { Container, Title, FormContainer, BtnContainer } from './InfoFrom.style'
 
 export type LoginSelectorProps = {
-  onNext: (info: { gender: string; birthDate: string; name: string }) => void
+  onNext: (info: { gender: string; birthDate: string; name: string }) => void | Promise<void>
+  defaultValues?: {
+    gender?: 'MALE' | 'FEMALE'
+    birthDate?: string
+    name?: string
+  }
 }
+
 
 const schema = z.object({
   name: z.string().min(1, '이름을 입력해주세요.'),

--- a/src/components/signup/InfoForm/InfoFrom.style.ts
+++ b/src/components/signup/InfoForm/InfoFrom.style.ts
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+
+import { semanticColor } from '@/styles/colors';
+import { typoStyleMap } from '@/styles/typos';
+
+export const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Title = styled.div`
+  padding: 12px 22px;
+  ${typoStyleMap['head1']};
+  color: ${semanticColor.text.normal.primary};
+`;
+
+// form 태그 역할, 내부 아이템은 세로로 배치, gap 12px, margin-top 34px
+export const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  margin-top: 34px;
+  padding: 0 22px;
+  gap: 12px;
+`;
+
+// 버튼 컨테이너 - 화면 하단 고정, 좌우 패딩 22px를 뺀 너비, margin-bottom 50px
+export const BtnContainer = styled.div`
+  width: calc(100% - 44px);
+  position: absolute;
+  bottom: 0;
+  margin-bottom: 50px;
+`;
+
+// 성별 선택 버튼 그룹
+export const GenderButtonGroup = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+// 성별 버튼 스타일
+export const GenderButton = styled.button<{ selected: boolean }>`
+  flex: 1;
+  padding: 12px 0;
+  border-radius: 8px;
+  border: 1.5px solid;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  background-color: ${({ selected }) => (selected ? '#3B82F6' : '#FFFFFF')};
+  color: ${({ selected }) => (selected ? '#FFFFFF' : '#222222')};
+  border-color: ${({ selected }) => (selected ? '#3B82F6' : '#D1D5DB')};
+
+  &:hover {
+    border-color: ${({ selected }) => (selected ? '#3B82F6' : '#9CA3AF')};
+  }
+`;
+
+// 에러 텍스트
+export const ErrorText = styled.p`
+  color: #ef4444;
+  font-size: 12px;
+  margin-top: 4px;
+`;

--- a/src/components/signup/PasswordForm/PasswordForm.style.ts
+++ b/src/components/signup/PasswordForm/PasswordForm.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const Title = styled.div`
   margin-top: 74px;

--- a/src/components/signup/PasswordForm/PasswordForm.tsx
+++ b/src/components/signup/PasswordForm/PasswordForm.tsx
@@ -1,21 +1,29 @@
 'use client';
 
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import TextField from '@/components/TextField/TextField';
-import Button from '@/components/Button/Button';
-import { Container, FormContainer, BtnContainer } from './../EmailForm/EmailForm.style';
-import { BottomSheetBtnContainer, Title } from './PasswordForm.style';
 import { useEffect, useRef, useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
 import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import BottomSheet from '@/components/BottomSheet/BottomSheet';
+import Button from '@/components/Button/Button';
 import {
   BtnWrapper,
   Question,
   SheetBtn,
 } from '@/components/login/LoginSelector/LoginSelector.style';
-import Image from 'next/image';
-import BottomSheet from '@/components/BottomSheet/BottomSheet';
+import TextField from '@/components/TextField/TextField';
+
+import { Container, FormContainer, BtnContainer } from './../EmailForm/EmailForm.style';
+import { BottomSheetBtnContainer, Title } from './PasswordForm.style';
+
+
+
+
+
 
 const schema = z
   .object({

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,3 +1,18 @@
 /**
  * 모달 열기/닫기를 제어하는 커스텀 훅
  */
+
+import { useState, useCallback } from 'react'
+
+export function useModal() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const openModal = useCallback(() => setIsOpen(true), [])
+  const closeModal = useCallback(() => setIsOpen(false), [])
+
+  return {
+    isOpen,
+    openModal,
+    closeModal,
+  }
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,3 +2,16 @@
  * Axios 인스턴스 설정 파일
  * (기본 API 베이스 URL, 인터셉터 등 공통 설정 적용)
  */
+
+
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default axios;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -7,7 +7,7 @@
 import axios from 'axios';
 
 export const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseURL: 'http://localhost:8080',
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/src/types/funnel.type.ts
+++ b/src/types/funnel.type.ts
@@ -41,7 +41,7 @@ export type SignupSteps = {
     birthDate: string;
     name: string;
     agreement: boolean;
-    cosumptionType?: string;
+    consumptionType?: string;
     consumptionGoal?: string;
   };
 };

--- a/src/types/funnel.type.ts
+++ b/src/types/funnel.type.ts
@@ -1,4 +1,4 @@
-import type { ConsumptionType } from '@/constants/auth.constant';
+import { ConsumptionType } from '@/constants/auth.constant';
 
 export type SignupSteps = {
   이메일인증: { email?: string; verifyPassword?: number };
@@ -34,6 +34,7 @@ export type SignupSteps = {
     birthDate: string;
     name: string;
     agreement: boolean;
+    consumptionType?: ConsumptionType;
   };
   소비목적결과: {
     email: string;

--- a/src/types/funnel.type.ts
+++ b/src/types/funnel.type.ts
@@ -11,7 +11,7 @@ export type SignupSteps = {
     password: string;
     method: string;
     gender?: string;
-    birthDate?: number;
+    birthDate?: string;
     name?: string;
   };
 
@@ -20,7 +20,7 @@ export type SignupSteps = {
     password: string;
     method: string;
     gender: string;
-    birthDate: number;
+    birthDate: string;
     name: string;
     agreement?: boolean;
   };
@@ -29,7 +29,7 @@ export type SignupSteps = {
     password: string;
     method: string;
     gender: string;
-    birthDate: number;
+    birthDate: string;
     name: string;
     agreement: boolean;
   };
@@ -38,7 +38,7 @@ export type SignupSteps = {
     password: string;
     method: string;
     gender: string;
-    birthDate: number;
+    birthDate: string;
     name: string;
     agreement: boolean;
     cosumptionType?: string;

--- a/src/types/funnel.type.ts
+++ b/src/types/funnel.type.ts
@@ -1,3 +1,5 @@
+import type { ConsumptionType } from '@/constants/auth.constant';
+
 export type SignupSteps = {
   이메일인증: { email?: string; verifyPassword?: number };
   비밀번호설정: { email: string; password?: string };
@@ -41,7 +43,7 @@ export type SignupSteps = {
     birthDate: string;
     name: string;
     agreement: boolean;
-    consumptionType?: string;
+    consumptionType?: ConsumptionType;
     consumptionGoal?: string;
   };
 };

--- a/src/utils/reverseMap.ts
+++ b/src/utils/reverseMap.ts
@@ -1,0 +1,5 @@
+function reverseMap<T extends Record<string, string>>(map: T, value: string): keyof T | undefined {
+  return (Object.entries(map).find(([, v]) => v === value)?.[0]) as keyof T | undefined;
+}
+
+export default reverseMap;


### PR DESCRIPTION
## 🔥 Related Issues

- close https://github.com/FLEX-RATE/flexrate-front/issues/36

## 💜 작업 내용
- [x] ~ 회원가입 페이지 내 소비목적 선택 컴포넌트 구현 및 상태 관리
- [x] ~ 선택된 소비목적 value값으로 백엔드 API 요청 데이터 구성
- [x] ~ 회원가입 API 연동 및 성공/실패 처리 로직 작성

## ✅ PR Point
- 소비목적 선택 시 label은 프론트 UI에, value는 API 요청에 사용하는 로직 확인
- API 호출 성공 시 데이터가 제대로 전송되는지, 실패 시 에러 처리 로직 확인
- funnel step 이동과 상태 관리 로직이 정상 작동하는지 집중 리뷰 필요

## 😡 Trouble Shooting
- use-funnel 라이브러리 사용 시 타입 정의가 불명확해 일부 step context 타입이 맞지 않는 문제 발생
타입 안정성을 위해 명확한 타입 선언 (number -> string)
- 프론트에서 label과 value를 구분하여 UI와 API 데이터에 각각 적절히 사용하는 부분에서 어려움 발생
reverseMap 함수로 라벨과 키 값 간 변환 문제 해결

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/user-attachments/assets/5e65dfe7-4794-48a6-acf4-e784fa4a43be)

![image](https://github.com/user-attachments/assets/7aa0abd4-ad9e-4f64-bab9-b36db535b563)

![image](https://github.com/user-attachments/assets/9612e558-4f8d-4273-8feb-03c7ea528a6d)

![image](https://github.com/user-attachments/assets/44d670cd-5096-40fb-a1c6-0832f355568e)

![image](https://github.com/user-attachments/assets/55ac8ead-751c-468f-9aba-93df9b13f5d5)

![image](https://github.com/user-attachments/assets/42a26eb2-6a02-4022-814d-6924bde6bd1f)

![image](https://github.com/user-attachments/assets/a6619ace-6ab5-4086-a968-e32fb1a58c62)


![image](https://github.com/user-attachments/assets/3dd04ad5-cd9d-4046-8572-69bc093f580b)


## 📚 Reference
https://use-funnel.slash.page/ko/docs/overview


