### PR TITLE
feat: 관리자 페이지 고객 대출 정보 조회 API 연동 & 상태 변경 모달 구현

### DIFF
--- a/src/apis/adminLoans.ts
+++ b/src/apis/adminLoans.ts
@@ -1,4 +1,5 @@
 import { LoanApiResponse, PatchLoanStatusPayload } from '@/types/admin.type';
+
 import { apiClient } from './client';
 
 /**
@@ -38,4 +39,24 @@ export async function patchLoanStatus(
       Authorization: `Bearer ${accessToken}`,
     },
   });
+}
+
+/**
+ * 관리자 대출 신청 상세 조회 API
+ * @param applicationId 대출 ID
+ * @param accessToken 인증 토큰
+ * @returns 대출 신청 상세 정보
+ *
+ * @since 2025.05.26
+ * @author 권민지
+ */
+export async function getLoanApplicationDetail(
+  applicationId: number,
+  accessToken: string
+): Promise<LoanApiResponse> {
+  const { data } = await apiClient.get<LoanApiResponse>(`/api/admin/loans/${applicationId}/detail`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return data;
 }

--- a/src/apis/adminLoans.ts
+++ b/src/apis/adminLoans.ts
@@ -1,4 +1,4 @@
-import { LoanApiResponse, PatchLoanStatusPayload } from '@/types/admin.type';
+import { LoanApiResponse, LoanDetailsApiResponse, PatchLoanStatusPayload } from "@/types/admin.type";
 
 import { apiClient } from './client';
 
@@ -53,8 +53,8 @@ export async function patchLoanStatus(
 export async function getLoanApplicationDetail(
   applicationId: number,
   accessToken: string
-): Promise<LoanApiResponse> {
-  const { data } = await apiClient.get<LoanApiResponse>(`/api/admin/loans/${applicationId}/detail`, {
+): Promise<LoanDetailsApiResponse> {
+  const { data } = await apiClient.get<LoanDetailsApiResponse>(`/api/admin/loans/${applicationId}/detail`, {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
 

--- a/src/apis/adminMembers.ts
+++ b/src/apis/adminMembers.ts
@@ -1,10 +1,14 @@
 import { GetAdminMembersResponse, PatchMemberPayload } from '@/types/admin.type';
+
 import { apiClient } from './client';
 
 /**
  * 관리자 회원 목록 조회 API
  * @param params 쿼리 파라미터
  * @param accessToken 인증 토큰
+ * 
+ * @since 2025.05.16
+ * @author 권민지
  */
 export async function getMembers(
   params: Record<string, string>,
@@ -23,6 +27,9 @@ export async function getMembers(
  * @param payload 수정할 데이터
  * @param accessToken 인증 토큰
  * @returns void
+ *
+ * @since 2025.05.16
+ * @author 권민지
  */
 export async function patchMember(
   userId: number,

--- a/src/app/admin/loan-application/page.style.ts
+++ b/src/app/admin/loan-application/page.style.ts
@@ -27,32 +27,51 @@ export const FilterLabel = styled.p`
     min-width: fit-content;
 `;
 
+export const ModalColumnContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ModalRowContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+`;
+
 export const ModalTitle = styled.div`
   padding: 12px 0px 12px 0px;
   ${typoStyleMap['title3']};
   color: ${semanticColor.text.normal.primary};
 `;
 
+export const ModalSubTitle = styled.div`
+  padding: 12px 0px 8px 0px;
+  ${typoStyleMap['body2_b']};
+  color: ${semanticColor.text.normal.sub1};
+`;
+
 export const ModalInfoContainer = styled.div`
+  min-width: fit-content;
   display: flex;
   flex-direction: row;
   gap: 1rem;
   padding-bottom: 1rem;
-  margin-bottom: 1rem;
   border-bottom: 1px solid ${semanticColor.border.inactive.default};
 `;
 
 export const ModalInfoKeyColumn = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  min-width: 80px;
+  gap: 0.3rem;
 `;
 
 export const ModalInfoValueColumn = styled.div`
   display: flex;
   flex-direction: column;
   min-width: 250px;
-  gap: 0.5rem;
+  gap: 0.3rem;
 `;
 
 export const InfoLabel = styled.p`

--- a/src/app/admin/loan-application/page.style.ts
+++ b/src/app/admin/loan-application/page.style.ts
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
 
+import { semanticColor } from "@/styles/colors";
+import { typoStyleMap } from "@/styles/typos";
+
 export const PageContainer = styled.div`
     padding: 30px;
     width: 100%;
@@ -22,4 +25,42 @@ export const FilterLabel = styled.p`
     font-size: 1rem;
     color: #3c3c3c;
     min-width: fit-content;
+`;
+
+export const ModalTitle = styled.div`
+  padding: 12px 0px 12px 0px;
+  ${typoStyleMap['title3']};
+  color: ${semanticColor.text.normal.primary};
+`;
+
+export const ModalInfoContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid ${semanticColor.border.inactive.default};
+`;
+
+export const ModalInfoKeyColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const ModalInfoValueColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 250px;
+  gap: 0.5rem;
+`;
+
+export const InfoLabel = styled.p`
+  color: ${semanticColor.text.normal.sub2};
+  margin: 0;
+`;
+
+export const InfoValue = styled.p`
+  color: ${semanticColor.text.normal.sub2};
+  margin: 0;
 `;

--- a/src/app/admin/loan-application/page.style.ts
+++ b/src/app/admin/loan-application/page.style.ts
@@ -90,3 +90,10 @@ export const InfoBottomText = styled.div`
     color: ${semanticColor.text.normal.sub3};
     padding: 1rem 0 2rem 0;
 `;
+
+export const ErrorInfo = styled.div`
+  color: ${semanticColor.text.state.textError};
+  ${typoStyleMap['caption1_m']};
+  padding-left: 0.5rem;
+  margin-top: 0.2rem;
+`;

--- a/src/app/admin/loan-application/page.style.ts
+++ b/src/app/admin/loan-application/page.style.ts
@@ -84,3 +84,9 @@ export const InfoValue = styled.p`
   color: ${semanticColor.text.normal.sub2};
   margin: 0;
 `;
+
+export const InfoBottomText = styled.div`
+  text-align: center;
+    color: ${semanticColor.text.normal.sub3};
+    padding: 1rem 0 2rem 0;
+`;

--- a/src/app/admin/loan-application/page.style.ts
+++ b/src/app/admin/loan-application/page.style.ts
@@ -37,6 +37,7 @@ export const ModalRowContainer = styled.div`
   flex-direction: row;
   width: 100%;
   justify-content: space-between;
+  border-bottom: 1px solid ${semanticColor.border.inactive.default};
 `;
 
 export const ModalTitle = styled.div`
@@ -57,7 +58,7 @@ export const ModalInfoContainer = styled.div`
   flex-direction: row;
   gap: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid ${semanticColor.border.inactive.default};
+  
 `;
 
 export const ModalInfoKeyColumn = styled.div`
@@ -70,7 +71,7 @@ export const ModalInfoKeyColumn = styled.div`
 export const ModalInfoValueColumn = styled.div`
   display: flex;
   flex-direction: column;
-  min-width: 250px;
+  min-width: 300px;
   gap: 0.3rem;
 `;
 

--- a/src/app/admin/loan-application/page.tsx
+++ b/src/app/admin/loan-application/page.tsx
@@ -31,7 +31,7 @@ import {
   FilterLabel,
   ModalTitle,
   ModalInfoContainer,
-  ModalInfoKeyColumn, InfoLabel, InfoValue, ModalInfoValueColumn
+  ModalInfoKeyColumn, InfoLabel, InfoValue, ModalInfoValueColumn, ModalSubTitle, ModalColumnContainer, ModalRowContainer
 } from "./page.style";
 
 const PAGE_SIZE = 8;
@@ -339,12 +339,54 @@ const AdminLoanApplicationPage = () => {
 
   // 대출 거절 핸들러
   const handleRejectLoan = (applicationId: number) => {
-    
+    if (!accessToken) {
+      console.error('Access token is not available.');
+      return;
+    }
+
+    patchStatusMutation.mutate(
+      {
+        applicationId,
+        payload: { status: 'REJECTED', reason: '대출 거절 사유 입력' }, // 실제 사유는 폼에서 받아야 함
+        accessToken,
+      },
+      {
+        onSuccess: () => {
+          message.success('대출이 거절되었습니다.');
+          queryClient.invalidateQueries(['loanApplications']);
+        },
+        onError: (error) => {
+          console.error('대출 거절 실패:', error);
+          message.error('대출 거절에 실패했습니다.');
+        },
+      }
+    );
   }
 
   // 대출 승인 핸들러
   const handleApproveLoan = (applicationId: number) => {
-    
+    if (!accessToken) {
+      console.error('Access token is not available.');
+      return;
+    }
+
+    patchStatusMutation.mutate(
+      {
+        applicationId,
+        payload: { status: 'EXECUTED', reason: '대출 승인 사유 입력' }, // 실제 사유는 폼에서 받아야 함
+        accessToken,
+      },
+      {
+        onSuccess: () => {
+          message.success('대출이 승인되었습니다.');
+          queryClient.invalidateQueries(['loanApplications']);
+        },
+        onError: (error) => {
+          console.error('대출 승인 실패:', error);
+          message.error('대출 승인에 실패했습니다.');
+        },
+      }
+    );
   };
 
   return (
@@ -501,35 +543,109 @@ const AdminLoanApplicationPage = () => {
         />
 
         <LoanStatusChangeModal isOpen={isModalVisible} onOutsideClick={handleModalCancel}>
-          <ModalTitle>대출 상태 변경</ModalTitle>
+          <ModalColumnContainer>
+            <ModalTitle>대출 상태 변경</ModalTitle>
 
-          <ModalInfoContainer>
-            <ModalInfoKeyColumn>
-              <InfoLabel>신청자:</InfoLabel>
-              <InfoLabel>현재 상태:</InfoLabel>
-              <InfoLabel>대출 심사 일자:</InfoLabel>
-              <InfoLabel>대출 가능 한도:</InfoLabel>
-              <InfoLabel>초기 대출 금리:</InfoLabel>
-              <InfoLabel>금리 범위:</InfoLabel>
-              <InfoLabel>대출 금액:</InfoLabel>
-              <InfoLabel>대출 상환 기간:</InfoLabel>
-              <InfoLabel>소비 성향:</InfoLabel>
-              <InfoLabel>소비 목표:</InfoLabel>
-            </ModalInfoKeyColumn>
+            <ModalRowContainer>
+              <ModalInfoContainer>
+                <ModalInfoKeyColumn>
+                  <InfoLabel>신청자:</InfoLabel>
+                  <InfoLabel>소비 성향:</InfoLabel>
+                  <InfoLabel>소비 목표:</InfoLabel>
+                </ModalInfoKeyColumn>
 
-            <ModalInfoValueColumn>
-              <InfoValue>홍길동</InfoValue>
-              <InfoValue>대기중</InfoValue>
-              <InfoValue>2023.10.03</InfoValue>
-              <InfoValue>3,000,000원</InfoValue>
-              <InfoValue>연 14.5%</InfoValue>
-              <InfoValue>연 12.1% ~ 15.1%</InfoValue>
-              <InfoValue>1,000,000원</InfoValue>
-              <InfoValue>6개월</InfoValue>
-              <InfoValue>균형형</InfoValue>
-              <InfoValue>매달 소액의 저축을 목표로 해요.</InfoValue>
-            </ModalInfoValueColumn>
-          </ModalInfoContainer>
+                <ModalInfoValueColumn>
+                  <InfoValue>홍길동</InfoValue>
+                  <InfoValue>균형형</InfoValue>
+                  <InfoValue>매달 소액의 저축을 목표로 해요.</InfoValue>
+                </ModalInfoValueColumn>
+              </ModalInfoContainer>
+
+              <ModalInfoContainer>
+                <ModalInfoKeyColumn>
+                  <InfoLabel>현재 상태:</InfoLabel>
+                  <InfoLabel>대출 금액:</InfoLabel>
+                  <InfoLabel>대출 상환 기간:</InfoLabel>
+                </ModalInfoKeyColumn>
+
+                <ModalInfoValueColumn>
+                  <InfoValue>대기중</InfoValue>
+                  <InfoValue>1,000,000원</InfoValue>
+                  <InfoValue>6개월</InfoValue>
+                </ModalInfoValueColumn>
+              </ModalInfoContainer>
+            </ModalRowContainer>
+          </ModalColumnContainer>
+
+          <ModalColumnContainer>
+            <ModalSubTitle>대출 심사 결과</ModalSubTitle>
+
+            <ModalRowContainer>
+              <ModalInfoContainer>
+                <ModalInfoKeyColumn>
+                  <InfoLabel>대출 심사 일자:</InfoLabel>
+                  <InfoLabel>대출 가능 한도:</InfoLabel>
+                  <InfoLabel>초기 대출 금리:</InfoLabel>
+                </ModalInfoKeyColumn>
+
+                <ModalInfoValueColumn>
+                  <InfoValue>2023.10.03</InfoValue>
+                  <InfoValue>3,000,000원</InfoValue>
+                  <InfoValue>연 14.5%</InfoValue>
+                </ModalInfoValueColumn>
+              </ModalInfoContainer>
+
+              <ModalInfoContainer>
+                <ModalInfoKeyColumn>
+                  <InfoLabel>금리 범위:</InfoLabel>
+                  <InfoLabel>대출 금액:</InfoLabel>
+                  <InfoLabel>대출 상환 기간:</InfoLabel>
+                </ModalInfoKeyColumn>
+
+                <ModalInfoValueColumn>
+                  <InfoValue>연 12.1% ~ 15.1%</InfoValue>
+                  <InfoValue>1,000,000원</InfoValue>
+                  <InfoValue>6개월</InfoValue>
+                </ModalInfoValueColumn>
+              </ModalInfoContainer>
+            </ModalRowContainer>
+          </ModalColumnContainer>
+
+          <ModalColumnContainer>
+            <ModalSubTitle>대출 신청 정보</ModalSubTitle>
+
+            <ModalRowContainer>
+              <ModalInfoContainer>
+                <ModalInfoKeyColumn>
+                  <InfoLabel>고용 형태:</InfoLabel>
+                  <InfoLabel>연소득:</InfoLabel>
+                  <InfoLabel>주거 형태:</InfoLabel>
+                </ModalInfoKeyColumn>
+
+                <ModalInfoValueColumn>
+                  <InfoValue>정규직</InfoValue>
+                  <InfoValue>3,000,000원</InfoValue>
+                  <InfoValue>자가</InfoValue>
+                </ModalInfoValueColumn>
+              </ModalInfoContainer>
+
+              <ModalInfoContainer>
+                <ModalInfoKeyColumn>
+                  <InfoLabel>개인회생 여부:</InfoLabel>
+                  <InfoLabel>대출 목적:</InfoLabel>
+                </ModalInfoKeyColumn>
+
+                <ModalInfoValueColumn>
+                  <InfoValue>아니요</InfoValue>
+                  <InfoValue>생활비 충당</InfoValue>
+                </ModalInfoValueColumn>
+              </ModalInfoContainer>
+            </ModalRowContainer>
+          </ModalColumnContainer>
+
+          <div style={{display: 'flex', flexDirection: 'column', marginBottom: '2rem'}}>
+          </div>
+
 
           <SubContainer>
             <TextField value={''} onChange={() => {}} isDisabled={false}>

--- a/src/app/admin/loan-application/page.tsx
+++ b/src/app/admin/loan-application/page.tsx
@@ -203,9 +203,8 @@ const AdminLoanApplicationPage = () => {
     }));
   };
 
-  // 대출 상태 변경 핸들러
   const handleStatusChange = (
-    newValue: string,
+    _: string,
     dataIndex?: string,
     record?: LoanApplicationTableRow
   ) => {
@@ -214,18 +213,16 @@ const AdminLoanApplicationPage = () => {
       return;
     }
 
-    // 상태 변경을 바로 실행하지 않고 모달을 표시하기 위해 정보 저장
     setPendingStatusChange({
       record,
-      newStatus: newValue,
+      newStatus: '',
     });
 
-    // 폼 초기화
-    statusChangeForm.resetFields();
-
-    // 모달 표시
     setIsModalVisible(true);
+    setReason('');
+    setReasonError('');
   };
+
 
   // 모달 데이터 패치
   useEffect(() => {

--- a/src/app/admin/loan-application/page.tsx
+++ b/src/app/admin/loan-application/page.tsx
@@ -8,8 +8,13 @@ import { isAxiosError } from 'axios';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
 
+import { SubContainer } from "@/app/mypage/page.style";
 import Conditionbar from '@/components/admin/Conditionbar/Conditionbar';
 import DataTable from '@/components/admin/DataTable/DataTable';
+import LoanStatusChangeModal from "@/components/admin/LoanStatusChangeModal/LoanStatusChangeModal";
+import FlexrateButton from '@/components/Button/Button';
+import { FlexContainer } from "@/components/loanApplicationFunnel/CreditStep/CreditStep.style";
+import TextField from "@/components/TextField/TextField";
 import {
   LoanApplicationTableRow,
   useLoanApplicationsQuery,
@@ -19,7 +24,15 @@ import { useLoanFilterStore } from '@/stores/loanFilterStore';
 import type { LoanFilterType } from '@/types/loan.filter.type';
 import { filtersToLoanApplicationParams } from '@/utils/loanApplicationParams';
 
-import { PageContainer, ContentColumn, FilterRow, FilterLabel } from './page.style';
+import {
+  PageContainer,
+  ContentColumn,
+  FilterRow,
+  FilterLabel,
+  ModalTitle,
+  ModalInfoContainer,
+  ModalInfoKeyColumn, InfoLabel, InfoValue, ModalInfoValueColumn
+} from "./page.style";
 
 const PAGE_SIZE = 8;
 
@@ -324,6 +337,16 @@ const AdminLoanApplicationPage = () => {
     }));
   }, [data?.loanApplications, handleStatusChange]);
 
+  // 대출 거절 핸들러
+  const handleRejectLoan = (applicationId: number) => {
+    
+  }
+
+  // 대출 승인 핸들러
+  const handleApproveLoan = (applicationId: number) => {
+    
+  };
+
   return (
     <PageContainer>
       <ContentColumn>
@@ -477,25 +500,81 @@ const AdminLoanApplicationPage = () => {
           }}
         />
 
+        <LoanStatusChangeModal isOpen={isModalVisible} onOutsideClick={handleModalCancel}>
+          <ModalTitle>대출 상태 변경</ModalTitle>
+
+          <ModalInfoContainer>
+            <ModalInfoKeyColumn>
+              <InfoLabel>신청자:</InfoLabel>
+              <InfoLabel>현재 상태:</InfoLabel>
+              <InfoLabel>대출 심사 일자:</InfoLabel>
+              <InfoLabel>대출 가능 한도:</InfoLabel>
+              <InfoLabel>초기 대출 금리:</InfoLabel>
+              <InfoLabel>금리 범위:</InfoLabel>
+              <InfoLabel>대출 금액:</InfoLabel>
+              <InfoLabel>대출 상환 기간:</InfoLabel>
+              <InfoLabel>소비 성향:</InfoLabel>
+              <InfoLabel>소비 목표:</InfoLabel>
+            </ModalInfoKeyColumn>
+
+            <ModalInfoValueColumn>
+              <InfoValue>홍길동</InfoValue>
+              <InfoValue>대기중</InfoValue>
+              <InfoValue>2023.10.03</InfoValue>
+              <InfoValue>3,000,000원</InfoValue>
+              <InfoValue>연 14.5%</InfoValue>
+              <InfoValue>연 12.1% ~ 15.1%</InfoValue>
+              <InfoValue>1,000,000원</InfoValue>
+              <InfoValue>6개월</InfoValue>
+              <InfoValue>균형형</InfoValue>
+              <InfoValue>매달 소액의 저축을 목표로 해요.</InfoValue>
+            </ModalInfoValueColumn>
+          </ModalInfoContainer>
+
+          <SubContainer>
+            <TextField value={''} onChange={() => {}} isDisabled={false}>
+              <TextField.Label>변경 사유</TextField.Label>
+              <TextField.TextFieldBox placeholder={"변경 사유 입력"}/>
+            </TextField>
+          </SubContainer>
+          {/*<Form form={statusChangeForm} layout="vertical">*/}
+          {/*  <Form.Item*/}
+          {/*    name="reason"*/}
+          {/*    label="변경 사유"*/}
+          {/*    rules={[{ required: true, message: '변경 사유를 입력해주세요' }]}*/}
+          {/*  >*/}
+          {/*    <Input.TextArea rows={4} placeholder="상태 변경 사유를 입력해주세요" />*/}
+          {/*  </Form.Item>*/}
+          {/*</Form>*/}
+
+          <FlexContainer>
+            <FlexrateButton text="대출 거절" varient="ERROR" onClick={handleRejectLoan} />
+            <FlexrateButton
+              text="대출 승인"
+              varient="PRIMARY"
+              onClick={handleApproveLoan}
+            />
+          </FlexContainer>
+        </LoanStatusChangeModal>
         {/* 상태 변경 확인 모달 */}
-        <Modal
-          title="대출 상태 변경"
-          open={isModalVisible}
-          onOk={handleModalOk}
-          onCancel={handleModalCancel}
-          okText="확인"
-          cancelText="취소"
-        >
-          <Form form={statusChangeForm} layout="vertical">
-            <Form.Item
-              name="reason"
-              label="변경 사유"
-              rules={[{ required: true, message: '변경 사유를 입력해주세요' }]}
-            >
-              <Input.TextArea rows={4} placeholder="상태 변경 사유를 입력해주세요" />
-            </Form.Item>
-          </Form>
-        </Modal>
+        {/*<Modal*/}
+        {/*  title="대출 상태 변경"*/}
+        {/*  open={isModalVisible}*/}
+        {/*  onOk={handleModalOk}*/}
+        {/*  onCancel={handleModalCancel}*/}
+        {/*  okText="확인"*/}
+        {/*  cancelText="취소"*/}
+        {/*>*/}
+        {/*  <Form form={statusChangeForm} layout="vertical">*/}
+        {/*    <Form.Item*/}
+        {/*      name="reason"*/}
+        {/*      label="변경 사유"*/}
+        {/*      rules={[{ required: true, message: '변경 사유를 입력해주세요' }]}*/}
+        {/*    >*/}
+        {/*      <Input.TextArea rows={4} placeholder="상태 변경 사유를 입력해주세요" />*/}
+        {/*    </Form.Item>*/}
+        {/*  </Form>*/}
+        {/*</Modal>*/}
       </ContentColumn>
     </PageContainer>
   );

--- a/src/app/admin/loan-application/page.tsx
+++ b/src/app/admin/loan-application/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from "react";
 
 import { useQueryClient } from '@tanstack/react-query';
-import { Input, InputNumber, Select, Space, Button, DatePicker, Modal, Form, message } from 'antd';
+import { Input, InputNumber, Select, Space, Button, DatePicker, Form, message } from 'antd';
 import { isAxiosError } from 'axios';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
@@ -203,26 +203,24 @@ const AdminLoanApplicationPage = () => {
     }));
   };
 
-  const handleStatusChange = (
-    _: string,
-    dataIndex?: string,
-    record?: LoanApplicationTableRow
-  ) => {
-    if (!record?.applicationId || !accessToken || dataIndex !== 'status') {
-      console.error('상태 변경 실패: 필수 정보 누락', { record, accessToken, dataIndex });
-      return;
-    }
+  const handleStatusChange = useCallback(
+    (_: string, dataIndex?: string, record?: LoanApplicationTableRow) => {
+      if (!record?.applicationId || !accessToken || dataIndex !== 'status') {
+        console.error('상태 변경 실패: 필수 정보 누락', { record, accessToken, dataIndex });
+        return;
+      }
 
-    setPendingStatusChange({
-      record,
-      newStatus: '',
-    });
+      setPendingStatusChange({
+        record,
+        newStatus: record.status,
+      });
 
-    setIsModalVisible(true);
-    setReason('');
-    setReasonError('');
-  };
-
+      setIsModalVisible(true);
+      setReason('');
+      setReasonError('');
+    },
+    [accessToken]
+  );
 
   // 모달 데이터 패치
   useEffect(() => {
@@ -241,8 +239,6 @@ const AdminLoanApplicationPage = () => {
     setIsModalVisible(false);
     setPendingStatusChange(null);
 
-    // 중요: 상태 변경이 취소되었으므로 테이블을 원래 상태로 되돌려야 함
-    // 데이터를 다시 불러오거나 상태를 복원하는 로직 필요
     const params = filtersToLoanApplicationParams(filters, page, PAGE_SIZE);
     queryClient.invalidateQueries({
       queryKey: ['loanApplications', JSON.stringify(params), accessToken],
@@ -704,7 +700,7 @@ const AdminLoanApplicationPage = () => {
                 {detail?.applicationStatus === 'COMPLETED' && (
                   <FlexrateButton
                     text="초기 상태로 변경"
-                    varient="SECONDARY"
+                    varient="PRIMARY"
                     onClick={() => handleModalOk('NONE')}
                   />
                 )}

--- a/src/components/admin/EditableCell/EditableCell.tsx
+++ b/src/components/admin/EditableCell/EditableCell.tsx
@@ -35,10 +35,25 @@ const EditableCell = ({
   dataIndex,
   inputType,
   options,
+  record,
   children,
   handleChange,
   ...restProps
 }: EditableCellProps) => {
+  // 상태 컬럼일 시 select 대신 클릭만 처리
+  if (dataIndex === 'status') {
+    return (
+      <td {...restProps}
+        style={{ cursor: 'pointer', textAlign: 'center' }}
+        onClick={() => {
+          handleChange('', dataIndex, record);
+        }}
+      >
+        {children}
+      </td>
+    );
+  }
+
   const renderInputNode = () => {
     switch (inputType) {
       case 'text':

--- a/src/components/admin/EditableCell/EditableCell.tsx
+++ b/src/components/admin/EditableCell/EditableCell.tsx
@@ -12,7 +12,7 @@ type EditableCellProps = {
   record: Record<string, unknown>;
   index: number;
   children: ReactNode;
-  handleChange: (value: string) => void;
+  handleChange: (value: string, dataIndex?: string, record?: Record<string, unknown>) => void;
 } & TdHTMLAttributes<HTMLTableCellElement>;
 
 /**
@@ -22,6 +22,7 @@ type EditableCellProps = {
  * @param dataIndex 테이블 데이터 인덱스
  * @param inputType 입력 타입 (text, select, date)
  * @param options 셀렉트 옵션 (select 타입일 경우)
+ * @param record 현재 행 데이터
  * @param children 자식 요소
  * @param handleChange 셀 값 변경 핸들러
  * @param restProps 기타 HTML 속성
@@ -40,13 +41,14 @@ const EditableCell = ({
   handleChange,
   ...restProps
 }: EditableCellProps) => {
+
   // 상태 컬럼일 시 select 대신 클릭만 처리
   if (dataIndex === 'status') {
     return (
       <td {...restProps}
         style={{ cursor: 'pointer', textAlign: 'center' }}
         onClick={() => {
-          handleChange('', dataIndex, record);
+          handleChange(record.status as string, dataIndex, record);
         }}
       >
         {children}

--- a/src/components/admin/LoanStatusChangeModal/LoanStatusChangeModal.style.ts
+++ b/src/components/admin/LoanStatusChangeModal/LoanStatusChangeModal.style.ts
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+import { motion } from "framer-motion";
+
+import { semanticColor } from "@/styles/colors";
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+export const Sheet = styled(motion.div)`
+  position: absolute;
+  width: fit-content;
+  min-height: fit-content;
+  background-color: ${semanticColor.bg.default};
+  border-radius: 15px;
+  padding: 15px 35px 20px 35px;
+  transform: translate(-50%, -50%);
+  max-height: 60%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;

--- a/src/components/admin/LoanStatusChangeModal/LoanStatusChangeModal.tsx
+++ b/src/components/admin/LoanStatusChangeModal/LoanStatusChangeModal.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React, { useEffect, useRef } from "react";
+
+import { AnimatePresence } from 'framer-motion';
+import { Overlay, Sheet } from "@/components/admin/LoanStatusChangeModal/LoanStatusChangeModal.style";
+
+interface LoanStatusChangeModalProps {
+  isOpen: boolean;
+  children: React.ReactNode;
+  onOutsideClick?: () => void;
+}
+
+const LoanStatusChangeModal = ({ isOpen, children, onOutsideClick }: LoanStatusChangeModalProps) => {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        isOpen &&
+        sheetRef.current &&
+        !sheetRef.current.contains(event.target as Node) &&
+        onOutsideClick
+      ) {
+        onOutsideClick();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onOutsideClick]);
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <Overlay>
+          <Sheet
+            onClick={(e) => e.stopPropagation()}
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ type: 'tween', duration: 0.2 }}
+            ref={sheetRef}
+          >
+            {children}
+          </Sheet>
+        </Overlay>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default LoanStatusChangeModal;

--- a/src/constants/loan.constant.ts
+++ b/src/constants/loan.constant.ts
@@ -75,7 +75,7 @@ export const LOAN_PURPOSE_LABEL: Record<string, string> = {
 };
 
 // 개인회생 여부
-export function BANKRUPT_LABEL(v: boolean | null) {
+export function BANKRUPT_LABEL(v: boolean | null | undefined): string {
   if (v === null || v === undefined) return '-';
   return v ? '예' : '아니요';
 }

--- a/src/constants/loan.constant.ts
+++ b/src/constants/loan.constant.ts
@@ -41,10 +41,11 @@ export const loanStatusMap: Record<LoanStatusType, { title: string; description:
 
 export const STATUS_LABEL: Record<string, string> = {
   PENDING: '심사중',
-  EXECUTED: '실행됨',
-  REJECTED: '거절됨',
+  EXECUTED: '실행중',
+  REJECTED: '거절',
   COMPLETED: '상환 완료',
-  PRE_APPLIED: '신청 접수',
+  PRE_APPLIED: '신청 접수중',
+  NONE: '대출 상품 선택 전'
 };
 
 // 고용 형태

--- a/src/constants/loan.constant.ts
+++ b/src/constants/loan.constant.ts
@@ -38,3 +38,44 @@ export const loanStatusMap: Record<LoanStatusType, { title: string; description:
     description: `대출금이 입금되었습니다.\n내역을 마이페이지에서 확인하세요.`,
   },
 };
+
+export const STATUS_LABEL: Record<string, string> = {
+  PENDING: '심사중',
+  EXECUTED: '실행됨',
+  REJECTED: '거절됨',
+  COMPLETED: '상환 완료',
+  PRE_APPLIED: '신청 접수',
+};
+
+// 고용 형태
+export const EMPLOYMENT_TYPE_LABEL: Record<string, string> = {
+  FULL_TIME: '정규직',
+  CONTRACT: '계약직',
+  PART_TIME: '비정규직',
+  SELF_EMPLOYED: '자영업',
+  UNEMPLOYED: '무직',
+  ETC: '기타',
+};
+
+// 주거 형태
+export const RESIDENCE_TYPE_LABEL: Record<string, string> = {
+  OWN: '자가',
+  JEONSE: '전세',
+  MONTHLY: '월세',
+};
+
+// 대출 목적
+export const LOAN_PURPOSE_LABEL: Record<string, string> = {
+  LIVING: '생활비',
+  BUSINESS: '사업자금',
+  CAR: '자동차 구입',
+  EDUCATION: '교육비',
+  HOUSE: '주택자금',
+  ETC: '기타',
+};
+
+// 개인회생 여부
+export function BANKRUPT_LABEL(v: boolean | null) {
+  if (v === null || v === undefined) return '-';
+  return v ? '예' : '아니요';
+}

--- a/src/constants/loan.constant.ts
+++ b/src/constants/loan.constant.ts
@@ -45,7 +45,7 @@ export const STATUS_LABEL: Record<string, string> = {
   REJECTED: '거절',
   COMPLETED: '상환 완료',
   PRE_APPLIED: '신청 접수중',
-  NONE: '대출 상품 선택 전'
+  NONE: '초기'
 };
 
 // 고용 형태

--- a/src/hooks/useLoanApplicationsQuery.ts
+++ b/src/hooks/useLoanApplicationsQuery.ts
@@ -3,10 +3,10 @@ import React, { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
-import { getLoanApplications } from '@/apis/AdminLoans';
+import { getLoanApplications } from '@/apis/adminLoans';
+import { RawLoanApplication } from '@/types/admin.type';
 import { LoanFilterType } from '@/types/loan.filter.type';
 import { filtersToLoanApplicationParams } from '@/utils/loanApplicationParams';
-import { RawLoanApplication } from '@/types/admin.type';
 
 const PAGE_SIZE = 8;
 

--- a/src/hooks/useLoanApplicationsQuery.ts
+++ b/src/hooks/useLoanApplicationsQuery.ts
@@ -37,15 +37,17 @@ export interface LoanApplicationTableRow {
 function getLoanStatus(status: RawLoanApplication['status']) {
   switch (status) {
     case 'PRE_APPLIED':
-      return '신청 접수';
+      return '신청 접수중';
     case 'PENDING':
       return '심사중';
     case 'REJECTED':
-      return '거절됨';
+      return '거절';
     case 'EXECUTED':
-      return '실행됨';
+      return '실행중';
     case 'COMPLETED':
       return '상환 완료';
+    case 'NONE':
+      return '초기';
     default:
       return '-';
   }

--- a/src/hooks/usePatchLoanStatus.ts
+++ b/src/hooks/usePatchLoanStatus.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { patchLoanStatus } from '@/apis/AdminLoans';
+import { patchLoanStatus } from '@/apis/adminLoans';
 import { LoanFilterType } from '@/types/loan.filter.type';
 import { filtersToLoanApplicationParams } from '@/utils/loanApplicationParams';
 

--- a/src/hooks/usePatchLoanStatus.ts
+++ b/src/hooks/usePatchLoanStatus.ts
@@ -9,23 +9,26 @@ import { filtersToLoanApplicationParams } from '@/utils/loanApplicationParams';
  */
 function toRawStatus(
   status: string | undefined
-): 'PRE_APPLIED' | 'PENDING' | 'REJECTED' | 'EXECUTED' | 'COMPLETED' {
+): 'PRE_APPLIED' | 'PENDING' | 'REJECTED' | 'EXECUTED' | 'COMPLETED' | 'NONE' {
   switch (status) {
-    case '신청 접수':
+    case '신청 접수중':
     case 'PRE_APPLIED':
       return 'PRE_APPLIED';
     case '심사중':
     case 'PENDING':
       return 'PENDING';
-    case '거절됨':
+    case '거절':
     case 'REJECTED':
       return 'REJECTED';
-    case '실행됨':
+    case '실행중':
     case 'EXECUTED':
       return 'EXECUTED';
     case '상환 완료':
     case 'COMPLETED':
       return 'COMPLETED';
+    case '초기':
+    case 'NONE':
+      return 'NONE';
     default:
       throw new Error(`지원하지 않는 상태입니다: ${status}`);
   }

--- a/src/types/admin.type.ts
+++ b/src/types/admin.type.ts
@@ -14,7 +14,7 @@ export interface RawMember {
 
 export interface RawLoanApplication {
   id: number;
-  status: 'PRE_APPLIED' | 'PENDING' | 'REJECTED' | 'EXECUTED' | 'COMPLETED';
+  status: 'PRE_APPLIED' | 'PENDING' | 'REJECTED' | 'EXECUTED' | 'COMPLETED' | 'NONE';
   appliedAt: string;
   applicant: string;
   applicantId: number;

--- a/src/types/admin.type.ts
+++ b/src/types/admin.type.ts
@@ -29,6 +29,30 @@ export interface LoanApiResponse {
   loans: RawLoanApplication[];
 }
 
+export interface LoanDetailsApiResponse {
+  applicationId: number;
+  applicantName: string;
+  consumptionType: string | null;
+  consumeGoal: string | null;
+  applicationStatus: string | null;
+  requestedAmount: number | null;
+  repaymentStartDate: string | null;
+  repaymentEndDate: string | null;
+  repaymentMonths: number | null;
+  appliedAt: string | null;
+  approvedMaxAmount: number | null;
+  initialInterestRate: number | null;
+  interestRateMin: number | null;
+  interestRateMax: number | null;
+  lastInterestRate: number | null;
+  lastInterestDate: string | null;
+  employmentType: string | null;
+  annualIncome: number | null;
+  residenceType: string | null;
+  isBankrupt: boolean | null;
+  loanPurpose: string | null;
+}
+
 export interface PaginationInfo {
   currentPage: number;
   pageSize: number;

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,9 @@
+export function formatYMD(dateString?: string | null): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return '-';
+  const yy = String(date.getFullYear()).slice(-2);
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yy}.${mm}.${dd}`;
+}

--- a/src/utils/nullDisplay.ts
+++ b/src/utils/nullDisplay.ts
@@ -1,6 +1,6 @@
-export function displayValue(value: unknown, formatter?: (v: string | null | undefined) => string) {
+export function displayValue(value: unknown, formatter?: (v: string | number | null | undefined) => string) {
   if (value === null || value === undefined || value === '') return '-';
-  if (formatter) return formatter(String(value));
+  if (formatter) return formatter(value as never);
   if (typeof value === 'object') return JSON.stringify(value);
 
   return String(value);

--- a/src/utils/nullDisplay.ts
+++ b/src/utils/nullDisplay.ts
@@ -1,4 +1,7 @@
-export function displayValue(value: any, formatter?: (v: any) => string) {
+export function displayValue(value: unknown, formatter?: (v: string | null | undefined) => string) {
   if (value === null || value === undefined || value === '') return '-';
-  return formatter ? formatter(value) : value;
+  if (formatter) return formatter(String(value));
+  if (typeof value === 'object') return JSON.stringify(value);
+
+  return String(value);
 }

--- a/src/utils/nullDisplay.ts
+++ b/src/utils/nullDisplay.ts
@@ -1,0 +1,4 @@
+export function displayValue(value: any, formatter?: (v: any) => string) {
+  if (value === null || value === undefined || value === '') return '-';
+  return formatter ? formatter(value) : value;
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #53 

## 💜 작업 내용

- [x] 관리자 페이지 고객 대출 정보 조회 API 연동
- [x] 상태 변경 모달 구현
- [x] 고객 상태에 따른 버튼 분기처리
- [x] 대출 신청 관리 테이블 상태 변경 시, 모달 취소(바깥 클릭 등) 후에도 기존 상태가 유지되도록 로직 개선
- [x] 상태 변경 관련 전체 테스트 시나리오 점검 및 반영

## ✅ PR Point

상태 변환 시나리오별로 실제로 값이 올바르게 반영되는지 검토 부탁드립니다.

## 🧪 상태 변환 테스트 수행 목록

모든 상태 변환에서 모달 취소 시 기존 상태가 유지되는지, 확정 시 정상 반영되는지 테스트 완료

- [x] NONE -> PRE_APPLIED
- [x] PRE_APPLIED -> NONE
- [x] PENDING -> REJECTED
- [x] PENDING -> EXECUTED
- [x] EXECUTED -> REJECTED
- [x] EXECUTED -> COMPLETED
- [x] COMPLETED -> NONE
- [x] REJECTED -> NONE

## 😡 Trouble Shooting

EditableCell에서 handleChange('')로 인해 모달 취소 시 테이블 상태가 빈 값으로 보이는 현상이 있었습니다.
이 문제를 해결해주고자 handleChange 함수의 인자를 (record.status as string, ...)로 변경하여 항상 기존 상태값을 넘기도록 수정하였습니다.
또한 모달 취소 시 invalidateQueries로 서버 데이터와 동기화하여 원상복구를 보장해주었습니다.

## ☀ 스크린샷 / GIF / 화면 녹화

![2025-05-2623 00 28-ezgif com-speed](https://github.com/user-attachments/assets/7a00fd42-26e8-41eb-b0a1-7adebfd41e88)


