### PR TITLE
feat: 대출 심사 신청 및 대출 신청 API 연동

### DIFF
--- a/src/apis/customer.ts
+++ b/src/apis/customer.ts
@@ -1,4 +1,5 @@
 import { LoanStatusType } from '@/types/user.type';
+
 import { apiClient } from './client';
 
 /**

--- a/src/apis/loanApplication.ts
+++ b/src/apis/loanApplication.ts
@@ -1,0 +1,55 @@
+import {
+  LoanApplicationRequest,
+  LoanApplicationResponse,
+  LoanReviewApplicationRequest,
+  LoanReviewApplicationResponse,
+} from '@/types/loanApplication.type';
+
+import { apiClient } from './client';
+
+export const postLoanReviewApplication = async (
+  token: string,
+  body: LoanReviewApplicationRequest
+) => {
+  const { data } = await apiClient.post<LoanReviewApplicationResponse>(
+    '/api/loans/loan-review-application',
+    body,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+
+  return data;
+};
+
+export const getLoanReviewApplication = async (token: string) => {
+  const response = await apiClient.get<LoanReviewApplicationResponse>(
+    '/api/loans/loan-review-application',
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  return response.data;
+};
+
+export const postLoanApplication = async (token: string, body: LoanApplicationRequest) => {
+  const { data } = await apiClient.post<LoanApplicationResponse>(
+    '/api/loans/loan-application',
+    body,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+
+  return data;
+};
+
+export const getLoanApplication = async (token: string) => {
+  const response = await apiClient.get<LoanApplicationResponse>(
+    '/api/loans/loan-application-result',
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+
+  return response.data;
+};

--- a/src/app/admin/loan-application/page.tsx
+++ b/src/app/admin/loan-application/page.tsx
@@ -233,7 +233,7 @@ const AdminLoanApplicationPage = () => {
             accessToken,
           },
           {
-            onSuccess: (data) => {
+            onSuccess: () => {
               // 성공 메시지 표시
               message.success({ content: '상태가 성공적으로 변경되었습니다.', key: messageKey });
               // 모달 닫기

--- a/src/components/CircularChart/CircularChart.tsx
+++ b/src/components/CircularChart/CircularChart.tsx
@@ -73,8 +73,6 @@ const CircularChart = ({ loading = false, score, rank }: CircularChartProps) => 
     labels: ['KCB'],
   };
 
-  const series = [67];
-
   return (
     <Wrapper
       animate={

--- a/src/components/creditEvaluationStep/AgreementEvaluation/AgreementEvaluation.tsx
+++ b/src/components/creditEvaluationStep/AgreementEvaluation/AgreementEvaluation.tsx
@@ -9,12 +9,17 @@ import CircularChart from '@/components/CircularChart/CircularChart';
 import { Container, Title } from '@/components/loanApplicationFunnel/LoanApplicationFunnel.style';
 import { Description } from '@/components/loanApplicationFunnel/ReviewResultAndLoanApplication/ReviewResultAndLoanApplication.style';
 import { useCreditScoreEvaluate } from '@/hooks/useCreditScore';
+import { useSelectLoanProduct } from '@/hooks/useSelectLoanProduct';
 import { useUserStore } from '@/stores/userStore';
 
 import { BtnContainer, TextContainer, Wrapper } from './AgreementEvaluation.style';
 
+const PRODUCT_ID = 1;
+
 const AgreementEvaluation = () => {
   const user = useUserStore((state) => state.user);
+  const setUser = useUserStore((state) => state.setUser);
+  const { mutate } = useSelectLoanProduct();
 
   const router = useRouter();
   const [loading, setLoading] = useState(true);
@@ -28,6 +33,19 @@ const AgreementEvaluation = () => {
 
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(() => {
+    if (
+      user &&
+      creditResult?.creditScore != null &&
+      user.creditScore !== creditResult.creditScore
+    ) {
+      setUser({
+        ...user,
+        creditScore: creditResult.creditScore,
+      });
+    }
+  }, [user, creditResult?.creditScore, setUser]);
 
   return (
     <Wrapper>
@@ -52,7 +70,12 @@ const AgreementEvaluation = () => {
               <Button
                 text="대출 신청하기"
                 varient="PRIMARY"
-                onClick={() => router.push('/loan-application')}
+                onClick={() => {
+                  if (user?.recentLoanStatus === 'NONE') {
+                    mutate(PRODUCT_ID);
+                  }
+                  router.push('/loan-application');
+                }}
               />
             </BtnContainer>
           </>

--- a/src/components/loanApplicationFunnel/JobStep/JobStep.tsx
+++ b/src/components/loanApplicationFunnel/JobStep/JobStep.tsx
@@ -1,9 +1,16 @@
-import { FunnelContextMap } from '../LoanApplicationFunnel';
-import { BtnContainer, JobInformationContainer, MainContainer, SubTitle } from './JobStep.style';
-import { EMPLOYMENT_TYPE_OPTIONS } from '@/constants/loan.constant';
 import Accordion from '@/components/Accordion/Accordion';
 import Button from '@/components/Button/Button';
+import {
+  EMPLOYMENT_TYPE,
+  EMPLOYMENT_TYPE_MAP,
+  EMPLOYMENT_TYPE_OPTIONS,
+} from '@/constants/loan.constant';
+import { reverseMap } from '@/utils/signup.util';
+
+import { FunnelContextMap } from '../LoanApplicationFunnel';
 import { Container } from '../LoanApplicationFunnel.style';
+
+import { BtnContainer, JobInformationContainer, MainContainer, SubTitle } from './JobStep.style';
 
 interface Props {
   value: FunnelContextMap['직업정보입력'];
@@ -12,6 +19,8 @@ interface Props {
 }
 
 export const JobStep = ({ value, onChange, onNext }: Props) => {
+  const selectedKorean = reverseMap(EMPLOYMENT_TYPE_MAP, value.employmentType);
+
   return (
     <Container>
       <MainContainer>
@@ -20,13 +29,18 @@ export const JobStep = ({ value, onChange, onNext }: Props) => {
           <Accordion
             options={EMPLOYMENT_TYPE_OPTIONS}
             title="고용 형태"
-            value={value.employmentType}
-            onSelect={(selected) => onChange({ ...value, employmentType: selected })}
+            value={selectedKorean}
+            onSelect={(selected) =>
+              onChange({
+                ...value,
+                employmentType: EMPLOYMENT_TYPE_MAP[selected as EMPLOYMENT_TYPE],
+              })
+            }
           />
         </JobInformationContainer>
       </MainContainer>
       <BtnContainer>
-        <Button text="다음으로" onClick={onNext} />
+        <Button text="다음으로" onClick={onNext} disabled={!value.employmentType} />
       </BtnContainer>
     </Container>
   );

--- a/src/components/loanApplicationFunnel/PurposeStep/PurposeStep.tsx
+++ b/src/components/loanApplicationFunnel/PurposeStep/PurposeStep.tsx
@@ -1,14 +1,17 @@
 import Accordion from '@/components/Accordion/Accordion';
+import Button from '@/components/Button/Button';
+import { PURPOSE_TYPE, PURPOSE_TYPE_MAP, PURPOSE_TYPE_OPTIONS } from '@/constants/loan.constant';
+import { reverseMap } from '@/utils/signup.util';
+
 import { FunnelContextMap } from '../LoanApplicationFunnel';
 import { Container } from '../LoanApplicationFunnel.style';
+
 import {
   BtnContainer,
   MainContainer,
   PurposeInformationContainer,
   SubTitle,
 } from './PurposeStep.style';
-import { PURPOSE_TYPE_OPTIONS } from '@/constants/loan.constant';
-import Button from '@/components/Button/Button';
 
 interface PurposeStepProps {
   value: FunnelContextMap['대출목적입력'];
@@ -17,6 +20,8 @@ interface PurposeStepProps {
 }
 
 export const PurposeStep = ({ value, onChange, onSubmit }: PurposeStepProps) => {
+  const selectedKorean = reverseMap(PURPOSE_TYPE_MAP, value.loanPurpose);
+
   return (
     <Container>
       <MainContainer>
@@ -25,13 +30,15 @@ export const PurposeStep = ({ value, onChange, onSubmit }: PurposeStepProps) => 
           <Accordion
             options={PURPOSE_TYPE_OPTIONS}
             title="목적"
-            value={value.loanPurpose}
-            onSelect={(selected) => onChange({ ...value, loanPurpose: selected })}
+            value={selectedKorean}
+            onSelect={(selected) =>
+              onChange({ ...value, loanPurpose: PURPOSE_TYPE_MAP[selected as PURPOSE_TYPE] })
+            }
           />
         </PurposeInformationContainer>
       </MainContainer>
       <BtnContainer>
-        <Button text="다음으로" onClick={onSubmit} />
+        <Button text="다음으로" onClick={onSubmit} disabled={!value.loanPurpose} />
       </BtnContainer>
     </Container>
   );

--- a/src/components/loanApplicationFunnel/ReviewResultAndLoanApplication/ReviewResultAndLoanApplication.tsx
+++ b/src/components/loanApplicationFunnel/ReviewResultAndLoanApplication/ReviewResultAndLoanApplication.tsx
@@ -1,5 +1,12 @@
+'use client';
+
+import Button from '@/components/Button/Button';
 import TextField from '@/components/TextField/TextField';
+import { useGetLoanReivewApplication } from '@/hooks/useLoanApplication';
+import { formatNumberComma } from '@/utils/formatNumberComma';
+
 import { FunnelContextMap } from '../LoanApplicationFunnel';
+
 import {
   BtnContainer,
   Caption,
@@ -20,7 +27,6 @@ import {
   TableItemKey,
   TableItemValue,
 } from './ReviewResultAndLoanApplication.style';
-import Button from '@/components/Button/Button';
 
 interface ReviewResultProps {
   value: FunnelContextMap['대출신청접수'];
@@ -29,85 +35,99 @@ interface ReviewResultProps {
 }
 
 const ReviewResultAndLoanApplication = ({ value, onChange, onSubmit }: ReviewResultProps) => {
+  const token = typeof window !== undefined ? localStorage.getItem('accessToken') ?? '' : '';
+  const { data: result } = useGetLoanReivewApplication(token);
+
+  const loanLimit = result ? formatNumberComma(result?.loanLimit) : '';
+
   return (
-    <Container>
-      <MainContainer>
-        <SubTitle>상세 내용</SubTitle>
-        <TableContainer>
-          <TableItem>
-            <TableItemKey>성명</TableItemKey>
-            <TableItemValue>Fisa</TableItemValue>
-          </TableItem>
-          <TableItem>
-            <TableItemKey>대출 심사 일자</TableItemKey>
-            <TableItemValue>2023.10.03</TableItemValue>
-          </TableItem>
-          <TableItem>
-            <TableItemKey>대출 가능 한도</TableItemKey>
-            <TableItemValue>
-              <TableItemValue $isStrong={true}>3,000,000,000</TableItemValue>원
-            </TableItemValue>
-          </TableItem>
-          <TableItem>
-            <TableItemKey>초기 대출 금리</TableItemKey>
-            <TableItemValue>
-              연 <TableItemValue $isStrong={true}>14.5%</TableItemValue>
-            </TableItemValue>
-          </TableItem>
-          <TableItem>
-            <TableItemKey>금리 범위</TableItemKey>
-            <TableItemValue>
-              연 <TableItemValue $isStrong={true}>12.5% ~ 15.1%</TableItemValue>
-            </TableItemValue>
-          </TableItem>
-          <CaptionContainer>
-            <Caption>· 기준금리 4.25% + 가산금리 10.35% - 우대금리 0.1%</Caption>
-            <br />
-            <Caption>
-              · 위 대출금리는 현재 약정 시 조건이며, 대출 실행일의 기준금리에 따라 변동될 수
-              있습니다.
-            </Caption>
-          </CaptionContainer>
-        </TableContainer>
-        <LoanApplicationContainer>
-          <SubTitle>대출 신청 접수</SubTitle>
-          <Description>
-            대출 가능 한도 내에서
-            <br />
-            대출 신청 금액을 조정하 기입해주세요
-          </Description>
-          <TextField
-            value={value.loanAmount.toString()}
-            onChange={(updatedValue) =>
-              onChange({ ...value, loanAmount: Number(updatedValue) || 0 })
-            }
-          >
-            <TextField.Label helperText="단위: 원">대출 금액</TextField.Label>
-            <TextField.TextFieldBox placeholder="숫자만 입력하세요" />
-          </TextField>
-          <SubDescriptionContainer>
-            <SubDescription>
-              대출 금액은 <SubDescription $isStrong={true}>최대 한도 금액</SubDescription>까지
-              가능합니다
-            </SubDescription>
-          </SubDescriptionContainer>
-          <MiniTitle>대출 상환 기간</MiniTitle>
-          <SliderContainer>
-            <SliderTitle>{value.repaymentMonth}개월</SliderTitle>
-            <Slider
-              type="range"
-              min={1}
-              max={12}
-              value={value.repaymentMonth}
-              onChange={(e) => onChange({ ...value, repaymentMonth: Number(e.target.value) || 0 })}
-            ></Slider>
-          </SliderContainer>
-        </LoanApplicationContainer>
-      </MainContainer>
-      <BtnContainer>
-        <Button text="대출 신청하기" onClick={onSubmit} />
-      </BtnContainer>
-    </Container>
+    result && (
+      <Container>
+        <MainContainer>
+          <SubTitle>상세 내용</SubTitle>
+          <TableContainer>
+            <TableItem>
+              <TableItemKey>성명</TableItemKey>
+              <TableItemValue>{result.name}</TableItemValue>
+            </TableItem>
+            <TableItem>
+              <TableItemKey>대출 심사 일자</TableItemKey>
+              <TableItemValue>{result.screeningDate}</TableItemValue>
+            </TableItem>
+            <TableItem>
+              <TableItemKey>대출 가능 한도</TableItemKey>
+              <TableItemValue>
+                <TableItemValue $isStrong={true}>{loanLimit}</TableItemValue>원
+              </TableItemValue>
+            </TableItem>
+            <TableItem>
+              <TableItemKey>초기 대출 금리</TableItemKey>
+              <TableItemValue>
+                연 <TableItemValue $isStrong={true}>{result.initialRate}%</TableItemValue>
+              </TableItemValue>
+            </TableItem>
+            <TableItem>
+              <TableItemKey>금리 범위</TableItemKey>
+              <TableItemValue>
+                연{' '}
+                <TableItemValue $isStrong={true}>
+                  {result?.rateRangeFrom}% ~ {result.rateRangeTo}%
+                </TableItemValue>
+              </TableItemValue>
+            </TableItem>
+            <CaptionContainer>
+              <Caption>· 기준금리 4.25% + 가산금리 10.35% - 우대금리 0.1%</Caption>
+              <br />
+              <Caption>
+                · 위 대출금리는 현재 약정 시 조건이며, 대출 실행일의 기준금리에 따라 변동될 수
+                있습니다.
+              </Caption>
+            </CaptionContainer>
+          </TableContainer>
+          <LoanApplicationContainer>
+            <SubTitle>대출 신청 접수</SubTitle>
+            <Description>
+              대출 가능 한도 내에서
+              <br />
+              대출 신청 금액을 조정하 기입해주세요
+            </Description>
+            <TextField
+              value={value.loanAmount.toString()}
+              onChange={(updatedValue) => {
+                if (/^\d*$/.test(updatedValue)) {
+                  onChange({ ...value, loanAmount: Number(updatedValue) || 0 });
+                }
+              }}
+            >
+              <TextField.Label helperText="단위: 원">대출 금액</TextField.Label>
+              <TextField.TextFieldBox placeholder="숫자만 입력하세요" />
+            </TextField>
+            <SubDescriptionContainer>
+              <SubDescription>
+                대출 금액은 <SubDescription $isStrong={true}>최대 한도 금액</SubDescription>까지
+                가능합니다
+              </SubDescription>
+            </SubDescriptionContainer>
+            <MiniTitle>대출 상환 기간</MiniTitle>
+            <SliderContainer>
+              <SliderTitle>{value.repaymentMonth}개월</SliderTitle>
+              <Slider
+                type="range"
+                min={1}
+                max={12}
+                value={value.repaymentMonth}
+                onChange={(e) =>
+                  onChange({ ...value, repaymentMonth: Number(e.target.value) || 0 })
+                }
+              ></Slider>
+            </SliderContainer>
+          </LoanApplicationContainer>
+        </MainContainer>
+        <BtnContainer>
+          <Button text="대출 신청하기" onClick={onSubmit} />
+        </BtnContainer>
+      </Container>
+    )
   );
 };
 

--- a/src/components/loanResult/ExecutedResult/ExecutedResult.style.ts
+++ b/src/components/loanResult/ExecutedResult/ExecutedResult.style.ts
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+import { semanticColor } from '@/styles/colors';
+import { typoStyleMap } from '@/styles/typos';
+
+export const MainContainer = styled.div`
+  position: relative;
+  margin: 0 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding: 11px 11px 80px 11px;
+  margin-bottom: 40px;
+`;
+
+export const SubTitle = styled.div`
+  margin-top: 12px;
+  ${typoStyleMap['title3']};
+  color: ${semanticColor.text.normal.primary};
+`;
+
+export const TableContainer = styled.div`
+  margin-top: 12px;
+  padding: 10px;
+  height: fit-content;
+  border-top: 1px solid ${semanticColor.border.active.default};
+  border-bottom: 1px solid ${semanticColor.border.active.default};
+`;
+
+export const TableItem = styled.span`
+  padding: 18px 8px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  border-bottom: 1px solid ${semanticColor.border.inactive.default};
+
+  &:last-child {
+    border: none;
+  }
+`;
+
+export const TableItemKey = styled.span`
+  ${typoStyleMap['body2_m']};
+  color: ${semanticColor.text.normal.sub2};
+`;
+
+export const TableItemValue = styled.span<{ $isStrong?: boolean }>`
+  ${typoStyleMap['body2_b']};
+  color: ${({ $isStrong }) =>
+    $isStrong ? semanticColor.text.normal.accent : semanticColor.text.normal.sub2};
+`;

--- a/src/components/loanResult/ExecutedResult/ExecutedResult.tsx
+++ b/src/components/loanResult/ExecutedResult/ExecutedResult.tsx
@@ -1,0 +1,43 @@
+import { LoanApplicationResponse } from '@/types/loanApplication.type';
+import { formatNumberComma } from '@/utils/formatNumberComma';
+
+import {
+  MainContainer,
+  SubTitle,
+  TableContainer,
+  TableItem,
+  TableItemKey,
+  TableItemValue,
+} from './ExecutedResult.style';
+
+export const ExecutedResult = ({ result }: { result: LoanApplicationResponse }) => {
+  const formatDate = (date: string) =>
+    `${date.slice(0, 4)}.${date.slice(4, 6)}.${date.slice(6, 8)}`;
+
+  const loanStartDate = formatDate(result.loanStartDate);
+  const loanApplicationAmount = formatNumberComma(result.loanApplicationAmount);
+
+  return (
+    <MainContainer>
+      <SubTitle>상세 내용</SubTitle>
+      <TableContainer>
+        <TableItem>
+          <TableItemKey>대출 신청 금액</TableItemKey>
+          <TableItemValue>
+            <TableItemValue $isStrong={true}>{loanApplicationAmount}</TableItemValue>원
+          </TableItemValue>
+        </TableItem>
+        <TableItem>
+          <TableItemKey>대출 신청 금액</TableItemKey>
+          <TableItemValue>
+            연 <TableItemValue $isStrong={true}>{result.loanInterestRate}%</TableItemValue>
+          </TableItemValue>
+        </TableItem>
+        <TableItem>
+          <TableItemKey>대출 실행일</TableItemKey>
+          <TableItemValue>{loanStartDate}</TableItemValue>
+        </TableItem>
+      </TableContainer>
+    </MainContainer>
+  );
+};

--- a/src/components/main/IntroduceHome/IntroduceHome.tsx
+++ b/src/components/main/IntroduceHome/IntroduceHome.tsx
@@ -127,16 +127,25 @@ const IntroduceHome = () => {
         {modalType === 'PRE_APPLIED' && (
           <>
             <TitleContainer>
-              <ModalTitle>신청 작성 중인 대출이 있어요</ModalTitle>
+              <ModalTitle>신청 중인 대출이 있어요</ModalTitle>
               <ModalSubTitle>
                 이전에 신청 중이던 대출이 있어요
                 <br />
-                이어서 신청할까요?
+                새로 신청할까요?
               </ModalSubTitle>
             </TitleContainer>
             <ModalBtnContainer>
               <Button
-                text="이어서 작성할게요"
+                size="M"
+                text="안할래요"
+                varient="TERTIARY"
+                onClick={() => {
+                  setModalType(null);
+                  router.push('/loan-application');
+                }}
+              />
+              <Button
+                text="새로 신청할게요"
                 varient="PRIMARY"
                 onClick={() => {
                   setModalType(null);

--- a/src/constants/loan.constant.ts
+++ b/src/constants/loan.constant.ts
@@ -1,6 +1,8 @@
+import { LoanStatusType } from '@/types/user.type';
+
 export type EMPLOYMENT_TYPE = '정규직' | '계약직' | '아르바이트' | '자영업' | '무직' | '기타';
 export type RESIDENT_TYPE = '자가' | '월세' | '전세' | '무주택';
-export type PURPOSE_TYPE = '생활비' | '사업자금' | '자동차 구입' | '교육비' | '주택자금' | '기타';
+export type PURPOSE_TYPE = '생활비' | '사업자금' | '자동차구입' | '교육비' | '주택자금' | '기타';
 
 export const EMPLOYMENT_TYPE_OPTIONS: EMPLOYMENT_TYPE[] = [
   '정규직',
@@ -16,15 +18,52 @@ export const RESIDENT_TYPE_OPTIONS: RESIDENT_TYPE[] = ['자가', '월세', '전�
 export const PURPOSE_TYPE_OPTIONS: PURPOSE_TYPE[] = [
   '생활비',
   '사업자금',
-  '자동차 구입',
+  '자동차구입',
   '교육비',
   '주택자금',
   '기타',
 ];
 
-export type LoanStatusType = 'PENDING' | 'REJECTED' | 'EXECUTED';
+export type EmploymentTypeEnum =
+  | 'FULL_TIME'
+  | 'CONTRACT'
+  | 'PART_TIME'
+  | 'SELF_EMPLOYED'
+  | 'UNEMPLOYED'
+  | 'ETC';
 
-export const loanStatusMap: Record<LoanStatusType, { title: string; description: string }> = {
+export type ResidenceTypeEnum = 'OWN' | 'JEONSE' | 'MONTHLY' | 'NONE';
+
+export type LoanPurposeEnum = 'LIVING' | 'BUSINESS' | 'CAR' | 'EDUCATION' | 'HOUSE' | 'ETC';
+
+export const EMPLOYMENT_TYPE_MAP: Record<EMPLOYMENT_TYPE, EmploymentTypeEnum> = {
+  정규직: 'FULL_TIME',
+  계약직: 'CONTRACT',
+  아르바이트: 'PART_TIME',
+  자영업: 'SELF_EMPLOYED',
+  무직: 'UNEMPLOYED',
+  기타: 'ETC',
+};
+
+export const RESIDENT_TYPE_MAP: Record<RESIDENT_TYPE, ResidenceTypeEnum> = {
+  자가: 'OWN',
+  월세: 'MONTHLY',
+  전세: 'JEONSE',
+  무주택: 'NONE',
+};
+
+export const PURPOSE_TYPE_MAP: Record<PURPOSE_TYPE, LoanPurposeEnum> = {
+  생활비: 'LIVING',
+  사업자금: 'BUSINESS',
+  자동차구입: 'CAR',
+  교육비: 'EDUCATION',
+  주택자금: 'HOUSE',
+  기타: 'ETC',
+};
+
+export const loanStatusMap: Partial<
+  Record<LoanStatusType, { title: string; description: string }>
+> = {
   PENDING: {
     title: '대출 신청 처리 중입니다',
     description: `영업일 기준 하루 이내에 알림을 통해\n심사 결과가 안내될 예정입니다`,

--- a/src/hooks/useClearFunnelContext.ts
+++ b/src/hooks/useClearFunnelContext.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { useLoanFunnelStore } from '@/stores/LoanFunnelStore';
+import { useUserStore } from '@/stores/userStore';
+
+export const useClearFunnelContext = () => {
+  const user = useUserStore((state) => state.user);
+  const previousUserEmail = useRef<string | null>(null);
+
+  useEffect(() => {
+    const currentEmail = user?.email ?? null;
+    const previousEmail = previousUserEmail.current;
+
+    if (previousEmail && currentEmail && previousEmail !== currentEmail) {
+      localStorage.removeItem('loan-funnel-context');
+      requestAnimationFrame(() => {
+        useLoanFunnelStore.getState().clearFunnelContext();
+      });
+    }
+
+    previousUserEmail.current = currentEmail;
+  }, [user?.email]);
+};

--- a/src/hooks/useLoanApplication.ts
+++ b/src/hooks/useLoanApplication.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import {
+  getLoanApplication,
+  getLoanReviewApplication,
+  postLoanApplication,
+  postLoanReviewApplication,
+} from '@/apis/loanApplication';
+import {
+  LoanApplicationRequest,
+  LoanApplicationResponse,
+  LoanReviewApplicationRequest,
+  LoanReviewApplicationResponse,
+} from '@/types/loanApplication.type';
+
+export const usePostLoanReviewApplication = (token: string) => {
+  return useMutation({
+    mutationFn: (body: LoanReviewApplicationRequest) => postLoanReviewApplication(token, body),
+  });
+};
+
+export const useGetLoanReivewApplication = (token: string) => {
+  return useQuery<LoanReviewApplicationResponse>({
+    queryKey: ['loan-review-result', [token]],
+    queryFn: () => getLoanReviewApplication(token),
+    enabled: !!token,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+};
+
+export const usePostLoanApplication = (token: string) => {
+  const router = useRouter();
+
+  return useMutation<LoanApplicationResponse, Error, LoanApplicationRequest>({
+    mutationFn: (data) => postLoanApplication(token, data),
+
+    onSuccess: (data) => {
+      console.log('대출 신청 성공:', data);
+      router.push('/loan-result');
+    },
+
+    onError: (error) => {
+      console.error('대출 신청 실패:', error);
+      alert('대출 신청 중 오류가 발생했습니다.');
+    },
+  });
+};
+
+export const useGetLoanApplication = (token: string) => {
+  return useQuery<LoanApplicationResponse>({
+    queryKey: ['loan-result', [token]],
+    queryFn: () => getLoanApplication(token),
+    enabled: !!token,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+};

--- a/src/hooks/useMembersQuery.ts
+++ b/src/hooks/useMembersQuery.ts
@@ -4,9 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
 import { getMembers } from '@/apis/admin';
+import { RawMember } from '@/types/admin.type';
 import { FilterType } from '@/types/filter.type';
 import { filtersToParams } from '@/utils/memberParams';
-import { RawMember } from '@/types/admin.type';
 const PAGE_SIZE = 8;
 
 /**

--- a/src/hooks/useResumeFunnel.ts
+++ b/src/hooks/useResumeFunnel.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+import { FunnelContextMap } from '@/components/loanApplicationFunnel/LoanApplicationFunnel';
+import { useLoanFunnelStore } from '@/stores/LoanFunnelStore';
+
+export const useResumeFunnel = () => {
+  const { funnelContext, setFunnelContext } = useLoanFunnelStore();
+
+  useEffect(() => {
+    const raw = localStorage.getItem('loan-funnel-context');
+    if (!raw) return;
+
+    try {
+      const parsed = JSON.parse(raw);
+      const saved = parsed?.state?.funnelContext;
+      if (!saved) return;
+
+      (Object.keys(saved) as (keyof FunnelContextMap)[]).forEach((step) => {
+        if (!funnelContext[step]) {
+          setFunnelContext(step, saved[step]);
+        }
+      });
+    } catch (e) {
+      console.warn('로컬스토리지 파싱 실패', e);
+    }
+  }, []);
+};

--- a/src/schemas/application.schema.ts
+++ b/src/schemas/application.schema.ts
@@ -1,0 +1,33 @@
+// schemas/application.schema.ts
+import { z } from 'zod';
+
+export const applicationSchema = z.object({
+  직업정보입력: z.object({
+    employmentType: z.string().min(1, '고용 형태를 선택해주세요'),
+  }),
+  신용정보입력: z.object({
+    annualIncome: z.preprocess(
+      (val) => (typeof val === 'string' ? Number(val) : val),
+      z.number().min(1, '연소득을 입력해주세요')
+    ),
+    residenceType: z.string().min(1, '주거 형태를 선택해주세요'),
+    isBankrupt: z.boolean(),
+  }),
+  대출목적입력: z.object({
+    loanPurpose: z.string().min(1, '대출 목적을 입력해주세요'),
+  }),
+  대출신청접수: z.object({
+    loanAmount: z.number().positive('대출 금액을 입력해주세요'),
+    repaymentMonth: z.number().positive('상환 기간을 입력해주세요'),
+  }),
+  약관동의: z.object({
+    agreePrivacy: z.boolean().refine((val) => val === true, {
+      message: '개인정보 제공에 동의해주세요.',
+    }),
+    agreeService: z.boolean().refine((val) => val === true, {
+      message: '서비스 이용 약관에 동의해주세요.',
+    }),
+  }),
+});
+
+export type ApplicationFormData = z.infer<typeof applicationSchema>;

--- a/src/stores/LoanFunnelStore.ts
+++ b/src/stores/LoanFunnelStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+import { FunnelContextMap } from '@/components/loanApplicationFunnel/LoanApplicationFunnel';
+
+type FunnelStore = {
+  funnelContext: Partial<FunnelContextMap>;
+  setFunnelContext: <K extends keyof FunnelContextMap>(step: K, data: FunnelContextMap[K]) => void;
+  clearFunnelContext: () => void;
+};
+
+export const useLoanFunnelStore = create<FunnelStore>()(
+  persist(
+    (set) => ({
+      funnelContext: {},
+      setFunnelContext: (step, data) =>
+        set((state) => ({
+          funnelContext: {
+            ...state.funnelContext,
+            [step]: data,
+          },
+        })),
+      clearFunnelContext: () => set({ funnelContext: {} }),
+    }),
+    {
+      name: 'loan-funnel-context',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -14,6 +14,7 @@ export type User = {
   email: string;
   recentLoanStatus: LoanStatusType;
   hasCreditScore: boolean;
+  creditScore?: number;
   consumeGoal?: string;
   consumptionType?: ConsumptionType;
 };
@@ -36,7 +37,7 @@ export const useUserStore = create<UserStore>()(
     }),
     {
       name: 'user-storage',
-      storage: createJSONStorage(() => sessionStorage),
+      storage: createJSONStorage(() => localStorage),
     }
   )
 );

--- a/src/types/loanApplication.type.ts
+++ b/src/types/loanApplication.type.ts
@@ -1,0 +1,31 @@
+export interface LoanReviewApplicationRequest {
+  employmentType: string;
+  annualIncome: number;
+  residenceType: string;
+  isBankrupt: boolean;
+  loanPurpose: string;
+}
+
+export interface LoanReviewApplicationResponse {
+  name: string;
+  screeningDate: string;
+  loanLimit: number;
+  initialRate: number;
+  rateRangeFrom: number;
+  rateRangeTo: number;
+  creditScore: number;
+  terms: number;
+}
+
+export interface LoanApplicationRequest {
+  loanAmount: number;
+  repaymentMonth: number;
+}
+
+export interface LoanApplicationResponse {
+  loanApplicationResult: string;
+  loanApplicationAmount: number;
+  loanInterestRate: number;
+  loanStartDate: string;
+  loanEndDate: string;
+}

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,1 +1,1 @@
-export type LoanStatusType = 'NONE' | 'PRE_APPLIED' | 'PENDING' | 'EXECUTED';
+export type LoanStatusType = 'NONE' | 'PRE_APPLIED' | 'PENDING' | 'EXECUTED' | 'REJECTED';

--- a/src/utils/formatNumberComma.ts
+++ b/src/utils/formatNumberComma.ts
@@ -1,0 +1,2 @@
+export const formatNumberComma = (num: number | string): string =>
+  num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');


### PR DESCRIPTION
## 🔥 Related Issues

- close #49 

## 💜 작업 내용

- [x] 대출 심사 신청 API 연동
- [x] 대출 신청 API 연동

## ✅ PR Point

- 숫자를 천 단위로 , 찍어서 string으로 포맷팅해주는 formatNumberComma를 만들었습니다. 다른 페이지에서 필요하실 때 이걸로 사용하시면 될 것 같습니다.
- 대출 심사 신청 시 작성하는 사용자 신용 정보를 전역상태로 담아서 신청 도중에 뒤로 가거나 다른 페이지로 이동했다가 돌아올 시, 같은 계정일 시 입력했던 값을 불러오는 useResumeFunnel를 작업하였습니다. 하지만 이는 다른 계정으로 후에 들어가서 새로운 대출 신청을 입력시 이전 계정의 로컬스토리지의 데이터가 날아가게 일단 해놨습니다.(로컬스토리지에 데이터가 무한히 쌓이는 걸 방지하기 위함)
- 대출 심사 결과를 사용자에 저장된 대출 상태에 따라 분기처리해주었습니다. 현재 대출을 신청하고 난 직후에는 무조건 'PENDING' 상태의 결과가 뜹니다. 추후 상태가 바뀌면 알람으로 대출 상태 결과를 알려주고 들어가거나 대출 신청하기 버튼을 누를 시에는 그 상태에 맞는 결과화면이 보여지게 됩니다.

## ☀ 스크린샷 / GIF / 화면 녹화
![May-28-2025 11-01-20](https://github.com/user-attachments/assets/1ce78ede-4582-4776-b0fd-7e8f3a7b6c04)

