### PR TITLE
feat: 메인페이지 API 연동

### DIFF
--- a/src/apis/interest.ts
+++ b/src/apis/interest.ts
@@ -1,0 +1,29 @@
+import { PeriodKey } from '@/types/chart.type';
+import { InterestCurrentResponse, InterestRateResponse, MainResponse } from '@/types/interest.type';
+
+import { apiClient } from './client';
+
+export const getInterestStats = async (token: string, periodType: PeriodKey) => {
+  const response = await apiClient.get<InterestRateResponse>('/loans/interest/stats', {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { periodType },
+  });
+
+  return response.data;
+};
+
+export const getInterestCurrent = async (token: string) => {
+  const response = await apiClient.get<InterestCurrentResponse>('/loans/interest/current', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  return response.data;
+};
+
+export const getMain = async (token: string) => {
+  const response = await apiClient.get<MainResponse>('/api/members/main', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  return response.data;
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,6 @@ const Home = () => {
 export default Home;
 
 const Container = styled.div`
-  height: 94vh;
+  height: 98vh;
   overflow-y: auto;
 `;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode, useState } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 export const Providers = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient());

--- a/src/components/AreaChart/AreaChart.style.ts
+++ b/src/components/AreaChart/AreaChart.style.ts
@@ -1,6 +1,10 @@
+'use client';
+
+import styled from '@emotion/styled';
+
 import { semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
+import { PeriodKey } from '@/types/chart.type';
 
 export const ChartContainer = styled.div`
   margin-top: 15px;
@@ -9,10 +13,43 @@ export const ChartContainer = styled.div`
   border-radius: 15px;
 `;
 
+export const ChartHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+`;
+
+export const ChartBtnContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin: 12px 0px;
+`;
+
 export const ChartTitle = styled.div`
   ${typoStyleMap['body2_eb']};
   color: ${semanticColor.text.normal.sub2};
   margin-left: 10px;
+`;
+
+export const PeriodBtn = styled.button<{ periodType: PeriodKey; btnKey: PeriodKey }>`
+  ${({ periodType, btnKey }) =>
+    periodType === btnKey ? typoStyleMap['body2_b'] : typoStyleMap['body2_m']};
+  cursor: pointer;
+  padding: 4px 10px;
+  background-color: ${({ periodType, btnKey }) =>
+    periodType === btnKey ? semanticColor.bgBtn.active.secondary : semanticColor.bgBtn.active.wt};
+  color: ${({ periodType, btnKey }) =>
+    periodType === btnKey ? semanticColor.text.normal.accent : semanticColor.text.normal.sub2};
+  border: 1px solid ${semanticColor.border.active.sub4};
+
+  &:first-of-type {
+    border-radius: 2px 0px 0px 2px;
+    border-right: none;
+  }
+  &:last-of-type {
+    border-radius: 0px 2px 2px 0px;
+    border-left: none;
+  }
 `;
 
 export const TooltipContainer = styled.div`

--- a/src/components/AreaChart/AreaChart.tsx
+++ b/src/components/AreaChart/AreaChart.tsx
@@ -1,135 +1,180 @@
+import { useMemo, useState } from 'react';
+
+import type { ApexOptions } from 'apexcharts';
 import dynamic from 'next/dynamic';
-import { ApexOptions } from 'apexcharts';
+
+import { useInterestStats } from '@/hooks/useInterestStats';
 import { semanticColor } from '@/styles/colors';
-import { ChartContainer, ChartTitle } from './AreaChart.style';
 import { typoStyleMap } from '@/styles/typos';
+import { PERIOD_TYPES, PeriodKey } from '@/types/chart.type';
+import { formatPeriodLabel } from '@/utils/formatPeriodLabel';
+
+import {
+  ChartBtnContainer,
+  ChartContainer,
+  ChartHeader,
+  ChartTitle,
+  PeriodBtn,
+} from './AreaChart.style';
 
 const ApexChart = dynamic(() => import('react-apexcharts'), { ssr: false });
 
 const cleanCSS = (css: string) => css.replace(/\s+/g, ' ').trim();
 
-const options: ApexOptions = {
-  chart: {
-    type: 'area',
-    background: semanticColor.bg.default,
-    zoom: {
-      enabled: true,
-      type: 'x',
-      autoScaleYaxis: true,
-    },
-    toolbar: {
-      show: false,
-    },
-  },
-  stroke: {
-    curve: 'smooth',
-    width: 2,
-    colors: [semanticColor.bg.primary],
-  },
-  fill: {
-    type: 'gradient',
-    gradient: {
-      shadeIntensity: 1,
-      opacityFrom: 1,
-      opacityTo: 0,
-      stops: [0, 100],
-    },
-  },
-  grid: {
-    show: false,
-  },
-  dataLabels: {
-    enabled: false,
-  },
-  yaxis: {
-    labels: {
-      show: false,
-    },
-  },
-  xaxis: {
-    type: 'datetime',
-    crosshairs: {
-      show: false,
-    },
-    labels: {
-      format: 'yyyy.MM.dd',
-    },
-    tickAmount: 6,
-    tooltip: {
-      enabled: false,
-    },
-  },
-  tooltip: {
-    followCursor: true,
-    enabled: true,
-    custom: ({ series, seriesIndex, dataPointIndex, w }) => {
-      const value = series[seriesIndex][dataPointIndex];
-      const date = new Date(w.globals.labels[dataPointIndex]);
-
-      const formattedDate = `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
-      const prevMonthStart = '2023.10.1';
-      const prevMonthEnd = '2023.10.31';
-      const changePercent = 3;
-
-      return `
-      <div style="
-        padding: 10px;
-        border-radius: 15px;
-        background: ${semanticColor.card.card1};
-        width: 137px;
-      ">
-        <div style="${cleanCSS(typoStyleMap['title2'])}; color: ${
-        semanticColor.text.normal.primary
-      };">${value}
-         <span style="${cleanCSS(typoStyleMap['caption3_b'])}; color: ${
-        semanticColor.text.normal.primary
-      };">%</span>
-         </div>
-        <div style="font-size: 12px; color: #9CA3AF; margin-top: 4px;">
-          ${prevMonthStart} - ${prevMonthEnd}
-        </div>
-        <div style="font-size: 13px; margin-top: 4px; color: #4B5563;">
-          이전 달 대비
-          <span style="color: #10B981; font-weight: 600; margin-left: 4px;">
-            ▲ ${changePercent}%
-          </span>
-        </div>
-      </div>
-    `;
-    },
-  },
-};
-
-const series = [
-  {
-    name: '금리',
-    data: [
-      [new Date('2025-03-01').getTime(), 10.2],
-      [new Date('2025-03-05').getTime(), 9.8],
-      [new Date('2025-03-11').getTime(), 11.0],
-      [new Date('2025-03-17').getTime(), 10.7],
-      [new Date('2025-03-23').getTime(), 9.3],
-      [new Date('2025-03-29').getTime(), 12.0],
-      [new Date('2025-04-02').getTime(), 11.5],
-      [new Date('2025-04-08').getTime(), 10.9],
-      [new Date('2025-04-13').getTime(), 11.7],
-      [new Date('2025-04-18').getTime(), 10.1],
-      [new Date('2025-04-22').getTime(), 12.3],
-      [new Date('2025-04-28').getTime(), 9.9],
-      [new Date('2025-05-03').getTime(), 10.4],
-      [new Date('2025-05-09').getTime(), 11.6],
-      [new Date('2025-05-15').getTime(), 9.5],
-      [new Date('2025-05-21').getTime(), 12.8],
-      [new Date('2025-05-27').getTime(), 10.6],
-    ],
-  },
-];
-
 const AreaChart = () => {
+  const [periodType, setPeriodType] = useState<PeriodKey>('DAILY');
+  const { data } = useInterestStats(periodType);
+
+  const series: ApexAxisChartSeries = [
+    {
+      name: '금리',
+      data:
+        data?.rates.map((item) => ({
+          x: formatPeriodLabel(item.period, periodType),
+          y: item.averageRate,
+        })) ?? [],
+    },
+  ];
+
+  const categories = useMemo(() => {
+    return data?.rates.map((d) => formatPeriodLabel(d.period, periodType)) ?? [];
+  }, [data, periodType]);
+
+  const getCompareText = (type: PeriodKey): string => {
+    switch (type) {
+      case 'DAILY':
+        return '어제 대비';
+      case 'WEEKLY':
+        return '지난 주 대비';
+      case 'MONTHLY':
+        return '지난 달 대비';
+      default:
+        return '';
+    }
+  };
+
+  const chartOptions: ApexOptions = useMemo(
+    () => ({
+      chart: {
+        id: 'interest-chart',
+        type: 'area',
+        background: semanticColor.bg.default,
+        zoom: {
+          enabled: true,
+          type: 'x',
+          autoScaleYaxis: true,
+        },
+        toolbar: { show: false },
+        events: {
+          zoomed: (_chartContext, { xaxis }) => {
+            if (xaxis?.max == null || xaxis?.min == null) return;
+
+            const rangeDays = (xaxis.max - xaxis.min) / (1000 * 60 * 60 * 24);
+            const maxRange = PERIOD_TYPES[periodType].maxRangeInDays;
+
+            if (rangeDays > maxRange) {
+              ApexCharts.exec('interest-chart', 'resetZoom');
+              alert(`${PERIOD_TYPES[periodType].label} 범위까지만 확대할 수 있어요`);
+            } else {
+              if (rangeDays <= 7) setPeriodType('DAILY');
+              else if (rangeDays <= 28) setPeriodType('WEEKLY');
+              else setPeriodType('MONTHLY');
+            }
+          },
+        },
+      },
+      stroke: {
+        curve: 'smooth',
+        width: 2,
+        colors: [semanticColor.bg.primary],
+      },
+      fill: {
+        type: 'gradient',
+        gradient: {
+          shadeIntensity: 1,
+          opacityFrom: 1,
+          opacityTo: 0,
+          stops: [0, 100],
+        },
+      },
+      grid: { show: false },
+      dataLabels: { enabled: false },
+      yaxis: { labels: { show: false } },
+      xaxis: {
+        type: 'category',
+        categories,
+        crosshairs: { show: false },
+        labels: {
+          rotate: -45,
+          style: { fontSize: '10px' },
+        },
+        tickAmount: 6,
+        tooltip: { enabled: false },
+      },
+      tooltip: {
+        followCursor: true,
+        enabled: true,
+        custom: (params: {
+          series: number[][];
+          seriesIndex: number;
+          dataPointIndex: number;
+          w: { globals: { labels: (string | number)[] } };
+        }) => {
+          const { series, seriesIndex, dataPointIndex } = params;
+          const value = series[seriesIndex][dataPointIndex];
+          const periodLabel = formatPeriodLabel(
+            data?.rates[dataPointIndex]?.period ?? '',
+            periodType
+          );
+
+          const compareText = getCompareText(periodType);
+          const changePercent = data?.rates[dataPointIndex]?.changeRatePercent ?? 0;
+          const formattedPercent = changePercent.toFixed(1);
+          const formattedValue = value.toFixed(1);
+
+          return `
+          <div style="padding: 10px; border-radius: 15px; background: ${
+            semanticColor.card.card1
+          }; width: 137px;">
+            <div style="${cleanCSS(typoStyleMap['title2'])}; color: ${
+            semanticColor.text.normal.primary
+          };">
+              ${formattedValue}<span style="${cleanCSS(typoStyleMap['caption3_b'])}; color: ${
+            semanticColor.text.normal.primary
+          };">%</span>
+            </div>
+            <div style="font-size: 12px; color: #9CA3AF; margin-top: 4px;">${periodLabel}</div>
+            <div style="font-size: 13px; margin-top: 4px; color: #4B5563;">
+              ${compareText} <span style="color: #10B981; font-weight: 600; margin-left: 4px;">▲ ${formattedPercent}%</span>
+            </div>
+          </div>
+        `;
+        },
+      },
+    }),
+    [categories, periodType, data]
+  );
+
   return (
     <ChartContainer>
-      <ChartTitle>나의 대출 금리 변화</ChartTitle>
-      <ApexChart options={options} series={series} type="area" height={180} />
+      <ChartHeader>
+        <ChartTitle>나의 대출 금리 변화</ChartTitle>
+        <ChartBtnContainer>
+          {Object.entries(PERIOD_TYPES).map(([key, { label }]) => (
+            <PeriodBtn
+              key={key}
+              btnKey={key as PeriodKey}
+              onClick={() => {
+                setPeriodType(key as PeriodKey);
+              }}
+              periodType={periodType}
+            >
+              {label}
+            </PeriodBtn>
+          ))}
+        </ChartBtnContainer>
+      </ChartHeader>
+      <ApexChart key={periodType} options={chartOptions} series={series} type="area" height={180} />
     </ChartContainer>
   );
 };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -37,7 +37,13 @@ const Header = ({ type, backIcon = false, isLoggedIn = false }: HeaderProps) => 
       return (
         <HeaderRightContainer>
           <Image src="/icons/alert_36.svg" width={36} height={36} alt="알림" />
-          <Image src="/icons/webee_36.svg" width={36} height={36} alt="마이페이지" />
+          <Image
+            src="/icons/webee_36.svg"
+            width={36}
+            height={36}
+            alt="마이페이지"
+            onClick={() => router.push('/mypage')}
+          />
         </HeaderRightContainer>
       );
     }

--- a/src/components/MainHasLoan/FirstPage/FirstPage.style.ts
+++ b/src/components/MainHasLoan/FirstPage/FirstPage.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { primitiveColor, semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -64,7 +65,7 @@ export const SmallTag = styled.div`
 `;
 
 export const BgContainer = styled.div<{ color: string }>`
-  padding: 16px 22px;
+  padding: 16px 22px 30px 22px;
   background-color: ${({ color }) =>
     color === 'gray' ? primitiveColor.background.cardBg : semanticColor.bg.default};
 `;
@@ -116,6 +117,7 @@ export const FlexContainer = styled.div`
 `;
 
 export const Description = styled.div<{ type: string }>`
+  cursor: pointer;
   ${typoStyleMap['caption1_m']};
   color: ${({ type }) =>
     type === 'sub2' ? semanticColor.text.normal.sub2 : semanticColor.text.normal.sub3};

--- a/src/components/MainHasLoan/FirstPage/FirstPage.tsx
+++ b/src/components/MainHasLoan/FirstPage/FirstPage.tsx
@@ -1,4 +1,13 @@
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+import AreaChart from '@/components/AreaChart/AreaChart';
 import Banner from '@/components/Banner/Banner';
+import { useMainFirstPage } from '@/hooks/useMainFirstPage';
+import { useMainSecondPage } from '@/hooks/useMainSecondPage';
+import { User } from '@/stores/userStore';
+import { formatKoreanMoneyUnit } from '@/utils/formatKoreanMoneyUnit';
+
 import {
   BgContainer,
   Body2,
@@ -21,56 +30,65 @@ import {
   UserProductContentContainer,
   Wrapper,
 } from './FirstPage.style';
-import AreaChart from '@/components/AreaChart/AreaChart';
-import Image from 'next/image';
 
-const FirstPage = () => {
+const FirstPage = ({ user }: { user: User | null }) => {
+  const router = useRouter();
+  const { interestCurrent, creditScore } = useMainFirstPage();
+  const { mainData } = useMainSecondPage();
+
+  const totalAmount =
+    mainData?.totalAmount != null ? formatKoreanMoneyUnit(mainData.totalAmount) : '-';
+
   return (
     <Wrapper>
       <BgContainer color="white">
         <MainTitleContainer>
-          <Title2>서채연님,</Title2>
+          <Title2>{user?.username}님,</Title2>
           <Body2>
-            현재 <Body3>300만원</Body3> 대출 상품을 이용 중입니다.
+            현재 <Body3>{totalAmount}</Body3> 대출 상품을 이용 중입니다.
           </Body2>
         </MainTitleContainer>
         <UserProductContainer>
           <ProductTitle>나의 대출 상품</ProductTitle>
           <UserProductContentContainer>
             <Title2 isStrong={true}>
-              Flex rate<Title2>신용대출</Title2>
+              Flexrate<Title2>신용대출</Title2>
             </Title2>
             <Tags>
-              <SmallTag>1년</SmallTag>
-              <SmallTag>300만원</SmallTag>
+              <SmallTag>{mainData?.repaymentMonth}개월</SmallTag>
+              <SmallTag>{totalAmount}</SmallTag>
             </Tags>
           </UserProductContentContainer>
         </UserProductContainer>
       </BgContainer>
       <BgContainer color="gray">
-        <Banner type="CONSERVATIVE" borderNone={true} />
+        <Banner type={user?.consumptionType} borderNone={true} />
         <AreaChart />
         <CardFlexContainer>
           <Card>
             <CardTitle>
-              12<SmallTitle>%</SmallTitle>
+              {interestCurrent?.currentRate}
+              <SmallTitle>%</SmallTitle>
             </CardTitle>
             <CardContentContainer>
               <SubTitle>오늘의 대출금리</SubTitle>
               <FlexContainer>
                 <Description type="sub2">어제 대비</Description>
                 <Image src={'/icons/greenUpArrow.svg'} alt="위 화살표" width={18} height={18} />
-                <PercentageText>3%</PercentageText>
+                <PercentageText>{interestCurrent?.changeRatePercent.toFixed(2)}%</PercentageText>
               </FlexContainer>
             </CardContentContainer>
           </Card>
           <Card>
             <CardTitle>
-              640<SmallTitle>점</SmallTitle>
+              {creditScore?.creditScore}
+              <SmallTitle>점</SmallTitle>
             </CardTitle>
             <CardContentContainer>
               <SubTitle>신용 평가 점수</SubTitle>
-              <Description type="sub2">평가 다시 받기 -&gt;</Description>
+              <Description type="sub2" onClick={() => router.push('/credit-evaluation')}>
+                평가 다시 받기 -&gt;
+              </Description>
             </CardContentContainer>
           </Card>
         </CardFlexContainer>

--- a/src/components/MainHasLoan/MainHasLoan.tsx
+++ b/src/components/MainHasLoan/MainHasLoan.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 
 import Image from 'next/image';
 
+import { useInitUser } from '@/hooks/useInitUser';
 import { useSlideTouch } from '@/hooks/useSlideTouch';
+import { useUserStore } from '@/stores/userStore';
 
 import FirstPage from './FirstPage/FirstPage';
 import {
@@ -17,9 +19,10 @@ import {
 import SecondPage from './SecondPage/SecondPage';
 
 const MainHasLoan = () => {
+  useInitUser();
+  const user = useUserStore((state) => state.user);
   const [index, setIndex] = useState(0);
   const totalSlides = 2;
-
   const {
     onTouchStart,
     onTouchMove,
@@ -67,7 +70,7 @@ const MainHasLoan = () => {
         onMouseLeave={onMouseLeave}
       >
         <Slide>
-          <FirstPage />
+          <FirstPage user={user} />
         </Slide>
         <Slide>
           <SecondPage />

--- a/src/components/MainHasLoan/SecondPage/SecondPage.style.ts
+++ b/src/components/MainHasLoan/SecondPage/SecondPage.style.ts
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
+
 import { primitiveColor, semanticColor } from '@/styles/colors';
 import { typoStyleMap } from '@/styles/typos';
-import styled from '@emotion/styled';
 
 export const MediumTitleWrapper = styled.span`
   ${typoStyleMap['title2']};

--- a/src/components/MainHasLoan/SecondPage/SecondPage.tsx
+++ b/src/components/MainHasLoan/SecondPage/SecondPage.tsx
@@ -1,4 +1,10 @@
+import Image from 'next/image';
+
 import LoanDashboard from '@/components/main/LoanDashboard/LoanDashboard';
+import { useMainFirstPage } from '@/hooks/useMainFirstPage';
+import { useMainSecondPage } from '@/hooks/useMainSecondPage';
+import { splitYMD } from '@/utils/dateFormat';
+
 import {
   BgContainer,
   Card,
@@ -9,112 +15,112 @@ import {
   SubTitle,
   Wrapper,
 } from '../FirstPage/FirstPage.style';
+
 import {
   CardFlexContainer,
-  DescriptionContainer,
-  FlexContainer,
-  GreenText,
   GridContainer,
   MediumTitle,
   MediumTitleWrapper,
 } from './SecondPage.style';
-import Image from 'next/image';
 
 const SecondPage = () => {
+  const { interestCurrent } = useMainFirstPage();
+  const { mainData } = useMainSecondPage();
+  const nextDate = mainData?.nextPaymentDate
+    ? new Date(mainData.nextPaymentDate).toISOString().slice(0, 10)
+    : undefined;
+
+  const {
+    year: nextRepaymentYear,
+    month: nextRepaymentMonth,
+    day: nextRepaymentDay,
+  } = splitYMD({ dateString: nextDate });
+
+  const {
+    year: startYear,
+    month: startMonth,
+    day: startDay,
+  } = splitYMD({ dateString: mainData?.startDate });
+
+  const recentDateFormatted = mainData?.recentRepaymentDate
+    ? new Date(mainData.recentRepaymentDate).toISOString().slice(0, 10).replace(/-/g, '.')
+    : '-';
+
   return (
-    <Wrapper>
-      <BgContainer color="white">
-        <CardFlexContainer>
-          <Card color="gray">
-            <MediumTitleWrapper>
-              <MediumTitle $isStrong={true}>
-                2020<MediumTitle>년</MediumTitle>
-              </MediumTitle>
-              <br />
-              <MediumTitle $isStrong={true}>
-                12<MediumTitle>월</MediumTitle>
-              </MediumTitle>
-              <MediumTitle $isStrong={true}>
-                10<MediumTitle>일</MediumTitle>
-              </MediumTitle>
-            </MediumTitleWrapper>
-            <CardContentContainer>
-              <SubTitle>
-                이번 달<br />
-                대출금 이자
-              </SubTitle>
-            </CardContentContainer>
-          </Card>
-          <Card color="gray">
-            <CardTitle>
-              0<SmallTitle>회차</SmallTitle>
-            </CardTitle>
-            <CardContentContainer>
-              <SubTitle>대출금 납부 회차</SubTitle>
-              <Description type="sub2">2023.09.15 오후 5시</Description>
-            </CardContentContainer>
-          </Card>
-        </CardFlexContainer>
-        <LoanDashboard />
-      </BgContainer>
-      <BgContainer color="gray">
-        <GridContainer>
-          <Card>
-            <MediumTitleWrapper>
-              <MediumTitle $isStrong={true}>
-                2020<MediumTitle>년</MediumTitle>
-              </MediumTitle>
-              <br />
-              <MediumTitle $isStrong={true}>
-                12<MediumTitle>월</MediumTitle>
-              </MediumTitle>
-              <MediumTitle $isStrong={true}>
-                10<MediumTitle>일</MediumTitle>
-              </MediumTitle>
-            </MediumTitleWrapper>
-            <CardContentContainer>
-              <SubTitle>대출 시작일</SubTitle>
-            </CardContentContainer>
-          </Card>
-          <Card>
-            <CardTitle>
-              9<SmallTitle>회차</SmallTitle>
-            </CardTitle>
-            <CardContentContainer>
-              <SubTitle>금리 변경 횟수</SubTitle>
-            </CardContentContainer>
-          </Card>
-          <Card>
-            <CardTitle>
-              9<SmallTitle>회차</SmallTitle>
-            </CardTitle>
-            <CardContentContainer>
-              <SubTitle>상환 횟수</SubTitle>
-              <DescriptionContainer>
-                <Description type="sub2">280,000원</Description>
-                <Description type="sub3">2023.09.15 오후 5시</Description>
-              </DescriptionContainer>
-            </CardContentContainer>
-          </Card>
-          <Card>
-            <CardTitle>
-              3<SmallTitle>회차</SmallTitle>
-            </CardTitle>
-            <CardContentContainer>
-              <SubTitle>연체 횟수</SubTitle>
-              <DescriptionContainer>
-                <FlexContainer>
-                  <Description type="sub2">280,000원</Description>
-                  <Image src={'/icons/greenUpArrow.svg'} width={18} height={18} alt="위 화살표" />
-                  <GreenText>3%</GreenText>
-                </FlexContainer>
-                <Description type="sub2">2023.09.15 오후 5시</Description>
-              </DescriptionContainer>
-            </CardContentContainer>
-          </Card>
-        </GridContainer>
-      </BgContainer>
-    </Wrapper>
+    mainData && (
+      <Wrapper>
+        <BgContainer color="white">
+          <LoanDashboard mainData={mainData} currentRate={interestCurrent?.currentRate ?? 0} />
+          <CardFlexContainer>
+            <Card color="gray">
+              <MediumTitleWrapper>
+                <MediumTitle $isStrong={true}>
+                  {nextRepaymentYear}
+                  <MediumTitle>년</MediumTitle>
+                </MediumTitle>
+                <br />
+                <MediumTitle $isStrong={true}>
+                  {nextRepaymentMonth}
+                  <MediumTitle>월</MediumTitle>
+                </MediumTitle>
+                <MediumTitle $isStrong={true}>
+                  {nextRepaymentDay}
+                  <MediumTitle>일</MediumTitle>
+                </MediumTitle>
+              </MediumTitleWrapper>
+              <CardContentContainer>
+                <SubTitle>
+                  이번 달<br />
+                  대출금 상환 일자
+                </SubTitle>
+              </CardContentContainer>
+            </Card>
+            <Card color="gray">
+              <CardTitle>
+                0<SmallTitle>회차</SmallTitle>
+              </CardTitle>
+              <CardContentContainer>
+                <SubTitle>대출금 납부 회차</SubTitle>
+                <Description type="sub2">{recentDateFormatted}</Description>
+              </CardContentContainer>
+            </Card>
+          </CardFlexContainer>
+        </BgContainer>
+        <BgContainer color="gray">
+          <GridContainer>
+            <Card>
+              <MediumTitleWrapper>
+                <MediumTitle $isStrong={true}>
+                  {startYear}
+                  <MediumTitle>년</MediumTitle>
+                </MediumTitle>
+                <br />
+                <MediumTitle $isStrong={true}>
+                  {startMonth}
+                  <MediumTitle>월</MediumTitle>
+                </MediumTitle>
+                <MediumTitle $isStrong={true}>
+                  {startDay}
+                  <MediumTitle>일</MediumTitle>
+                </MediumTitle>
+              </MediumTitleWrapper>
+              <CardContentContainer>
+                <SubTitle>대출 시작일</SubTitle>
+              </CardContentContainer>
+            </Card>
+            <Card>
+              <CardTitle>
+                {mainData?.loanRepaymentTransactionNum}
+                <SmallTitle>회차</SmallTitle>
+              </CardTitle>
+              <CardContentContainer>
+                <SubTitle>금리 변경 횟수</SubTitle>
+              </CardContentContainer>
+            </Card>
+          </GridContainer>
+        </BgContainer>
+      </Wrapper>
+    )
   );
 };
 

--- a/src/components/main/IntroduceHome/IntroduceHome.style.ts
+++ b/src/components/main/IntroduceHome/IntroduceHome.style.ts
@@ -8,6 +8,7 @@ import { typoStyleMap } from '@/styles/typos';
 
 export const Wrapper = styled.div`
   width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -109,5 +110,8 @@ export const BtnContainer = styled.div`
   width: calc(100% - 44px);
   position: absolute;
   bottom: 0;
-  margin-bottom: 50px;
+  @media (max-height: 670px) {
+    margin-bottom: 50px;
+  }
+  margin-bottom: 100px;
 `;

--- a/src/components/main/LoanDashboard/LoanDashboard.tsx
+++ b/src/components/main/LoanDashboard/LoanDashboard.tsx
@@ -1,4 +1,9 @@
 import Image from 'next/image';
+
+import ProgressBar from '@/components/ProgressBar/ProgressBar';
+import { InterestCurrentResponse, MainResponse } from '@/types/interest.type';
+import { formatNumberComma } from '@/utils/formatNumberComma';
+
 import {
   Account,
   AccountContainer,
@@ -11,29 +16,43 @@ import {
   TransparentCardContainer,
   TransparentCardTitle,
 } from './LoanDashboard.style';
-import ProgressBar from '@/components/ProgressBar/ProgressBar';
 
-const LoanDashboard = () => {
+const LoanDashboard = ({
+  mainData,
+  currentRate,
+}: {
+  mainData: MainResponse;
+  currentRate: number;
+}) => {
+  const totalAmount = formatNumberComma(mainData.totalAmount);
+  const monthlyPayment = formatNumberComma(mainData.monthlyPayment);
+  const monthlyPrincipal = formatNumberComma(mainData.monthlyPrincipal);
+  const monthlyInterest = formatNumberComma(mainData.monthlyInterest);
+
   return (
     <RecentLoanProgressContainer>
       <TitleContainer>
         <Title>나의 이번달 대출금</Title>
         <AccountContainer>
-          <Account>280,000원</Account>
+          <Account>{monthlyPayment}원</Account>
           <Image src={'/icons/badgeIc.svg'} width={97} height={18} alt="잘 상환 중이에요" />
         </AccountContainer>
       </TitleContainer>
-      <ProgressBar type="MAIN" currentStep={10} totalSteps={100} />
+      <ProgressBar type="MAIN" currentStep={mainData.repaymentRate} totalSteps={100} />
       <TransparentCardContainer>
         <TransparentCard>
           <TransparentCardTitle>원금</TransparentCardTitle>
-          <TransparentCardAccount>250,000원</TransparentCardAccount>
-          <Description>3,000,000원 / 12개월</Description>
+          <TransparentCardAccount>{monthlyPrincipal}원</TransparentCardAccount>
+          <Description>
+            {totalAmount}원 / {mainData.repaymentMonth}개월
+          </Description>
         </TransparentCard>
         <TransparentCard>
           <TransparentCardTitle>이자</TransparentCardTitle>
-          <TransparentCardAccount>30,000원</TransparentCardAccount>
-          <Description>3,000,000원 X 12/12개월</Description>
+          <TransparentCardAccount>{monthlyInterest}원</TransparentCardAccount>
+          <Description>
+            {totalAmount}원 X {currentRate} / {mainData.repaymentMonth}개월
+          </Description>
         </TransparentCard>
       </TransparentCardContainer>
     </RecentLoanProgressContainer>

--- a/src/hooks/useInterestStats.ts
+++ b/src/hooks/useInterestStats.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getInterestStats } from '@/apis/interest';
+import { PeriodKey } from '@/types/chart.type';
+
+export const useInterestStats = (periodType: PeriodKey) => {
+  return useQuery({
+    queryKey: ['interestStats', periodType],
+    queryFn: async () => {
+      const token = localStorage.getItem('accessToken') || '';
+      return getInterestStats(token, periodType);
+    },
+    enabled: !!periodType,
+  });
+};

--- a/src/hooks/useLoanApplication.ts
+++ b/src/hooks/useLoanApplication.ts
@@ -37,7 +37,6 @@ export const usePostLoanApplication = (token: string) => {
     mutationFn: (data) => postLoanApplication(token, data),
 
     onSuccess: (data) => {
-      console.log('대출 신청 성공:', data);
       router.push('/loan-result');
     },
 

--- a/src/hooks/useMainFirstPage.ts
+++ b/src/hooks/useMainFirstPage.ts
@@ -1,0 +1,30 @@
+import { useQueries } from '@tanstack/react-query';
+
+import { getCreditScore } from '@/apis/credit';
+import { getInterestCurrent } from '@/apis/interest';
+
+export const useMainFirstPage = () => {
+  const token = typeof window !== undefined ? localStorage.getItem('accessToken') ?? '' : '';
+
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: ['interestCurrent'],
+        queryFn: () => getInterestCurrent(token),
+        enabled: !!token,
+      },
+      {
+        queryKey: ['credit-score'],
+        queryFn: () => getCreditScore(token),
+        enabled: !!token,
+      },
+    ],
+  });
+
+  const [interestCurrentQuery, creditScoreQuery] = results;
+
+  return {
+    interestCurrent: interestCurrentQuery.data,
+    creditScore: creditScoreQuery.data,
+  };
+};

--- a/src/hooks/useMainSecondPage.ts
+++ b/src/hooks/useMainSecondPage.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMain } from '@/apis/interest';
+import { MainResponse } from '@/types/interest.type';
+
+export const useMainSecondPage = () => {
+  const token = typeof window !== undefined ? localStorage.getItem('accessToken') ?? '' : '';
+
+  const { data, isLoading, error } = useQuery<MainResponse>({
+    queryKey: ['mainSecondPage'],
+    queryFn: () => getMain(token),
+    enabled: !!token,
+  });
+
+  return {
+    mainData: data,
+    isLoading,
+    error,
+  };
+};

--- a/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
+++ b/src/styles/MobileGlobalStyle/MobileGlobalStyle.style.ts
@@ -48,6 +48,6 @@ export const AppContainer = styled.div`
 
 export const InnerContainer = styled.div`
   position: relative;
-  padding: 57px 0px 0px 0px;
+  padding: 30px 0px 0px 0px;
   box-sizing: border-box;
 `;

--- a/src/types/chart.type.ts
+++ b/src/types/chart.type.ts
@@ -1,0 +1,7 @@
+export const PERIOD_TYPES = {
+  DAILY: { label: '1일', maxRangeInDays: 7, xAxisFormat: 'yyyy.MM.dd' },
+  WEEKLY: { label: '1주일', maxRangeInDays: 28, xAxisFormat: "'W'w" },
+  MONTHLY: { label: '1개월', maxRangeInDays: 90, xAxisFormat: 'yyyy.MM' },
+} as const;
+
+export type PeriodKey = keyof typeof PERIOD_TYPES;

--- a/src/types/interest.type.ts
+++ b/src/types/interest.type.ts
@@ -1,0 +1,31 @@
+export interface InterestStatsInfo {
+  period: string;
+  averageRate: number;
+  changeRatePercent: number;
+}
+
+export interface InterestRateResponse {
+  rates: InterestStatsInfo[];
+  highestRate: number;
+  lowestRate: number;
+}
+
+export interface InterestCurrentResponse {
+  currentRate: number;
+  previousRate: number;
+  changeRatePercent: number;
+}
+
+export interface MainResponse {
+  monthlyPayment: number;
+  repaymentRate: number;
+  monthlyPrincipal: number;
+  monthlyInterest: number;
+  nextPaymentDate: string;
+  loanRepaymentTransactionNum: number;
+  recentRepaymentDate: string | null;
+  startDate: string;
+  interestChangedNum: number;
+  totalAmount: number;
+  repaymentMonth: number;
+}

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,9 +1,30 @@
-export function formatYMD(dateString?: string | null): string {
+export const formatYMD = ({ dateString }: { dateString?: string | null }): string => {
   if (!dateString) return '-';
+
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return '-';
+
   const yy = String(date.getFullYear()).slice(-2);
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const dd = String(date.getDate()).padStart(2, '0');
+
   return `${yy}.${mm}.${dd}`;
-}
+};
+
+export const splitYMD = ({
+  dateString,
+}: {
+  dateString?: string | null;
+}): {
+  year?: string;
+  month?: string;
+  day?: string;
+} => {
+  if (!dateString) return {};
+
+  const parts = dateString.split('-');
+  if (parts.length !== 3) return {};
+
+  const [year, month, day] = parts;
+  return { year, month, day };
+};

--- a/src/utils/formatKoreanMoneyUnit.ts
+++ b/src/utils/formatKoreanMoneyUnit.ts
@@ -1,0 +1,15 @@
+export const formatKoreanMoneyUnit = (amount: number): string => {
+  if (amount >= 10_000_000) {
+    return `${amount / 1_000_000}백만원`;
+  }
+  if (amount >= 1_000_000) {
+    return `${amount / 100_000}십만원`;
+  }
+  if (amount >= 100_000) {
+    return `${amount / 10_000}만원`;
+  }
+  if (amount >= 10_000) {
+    return `${amount / 1_000}천원`;
+  }
+  return `${amount.toLocaleString()}원`;
+};

--- a/src/utils/formatNumberComma.ts
+++ b/src/utils/formatNumberComma.ts
@@ -1,2 +1,4 @@
-export const formatNumberComma = (num: number | string): string =>
-  num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+export const formatNumberComma = (num?: number | string): string => {
+  if (num === undefined || num === null) return '-';
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};

--- a/src/utils/formatPeriodLabel.ts
+++ b/src/utils/formatPeriodLabel.ts
@@ -1,0 +1,24 @@
+import { PeriodKey } from '@/types/chart.type';
+
+const ordinal = ['첫째', '둘째', '셋째', '넷째', '다섯째'];
+
+export const formatPeriodLabel = (period: string, type: PeriodKey): string => {
+  if (type === 'DAILY') return period.replace(/-/g, '.');
+  if (type === 'MONTHLY') return period.replace('-', '.');
+
+  if (type === 'WEEKLY') {
+    const [yearStr, weekStr] = period.split('-W');
+    const year = Number(yearStr);
+    const week = Number(weekStr);
+
+    const firstDayOfYear = new Date(year, 0, 1);
+    const weekStartDate = new Date(firstDayOfYear.getTime() + (week - 1) * 7 * 24 * 60 * 60 * 1000);
+
+    const month = weekStartDate.getMonth() + 1;
+    const weekOfMonth = Math.ceil((weekStartDate.getDate() + weekStartDate.getDay()) / 7);
+
+    return `${month}월 ${ordinal[weekOfMonth - 1] ?? `${weekOfMonth}번째`} 주`;
+  }
+
+  return period;
+};


### PR DESCRIPTION
## 🔥 Related Issues

- close #59 

## 💜 작업 내용

- [x] 첫번째 슬라이드 화면 API
    - [x] `/api/members/mypage` 및 `/api/credit-score` => 로컬스토리지에 있는 userStore로 대체 가능
    - [x] `/loans/interest/stats`
    - [x] `/loans/interest/current`
- [x] 두번째 슬라이드 화면 API
    - [x] `/api/members/main`

## ✅ PR Point

- 백엔드 요구사항대로 일, 주, 월 별로 차트에서 볼 수 있도록 버튼 추가와 함께 데이터 연결을 진행했습니다.
- 지난 대비 변동률 및 대출 금리 같은 경우, 소수가 5자리가 넘어가는 현상이 있어.. 소수 첫째자리 및 둘째 자리까지 나오도록 설정하였습니다.
- 대출금 총액 같은 경우 메인페이지 타이틀에 만원 같이 단위식으로 기획이 되어있어, 백만원, 십만원, 만원, 천원 단위로 포맷팅해서 나타내도록 하였습니다.
- 기존 헤더에 위비 클릭 시, 마이페이지로 이동할 수 있도록 라우팅 연결을 진행했습니다.
- 신용 점수 같은 경우, 평가 다시 받기를 누르면 평가 화면으로 넘어가도록 라우팅 연결을 진행했습니다.
- 대출금리변화 차트는 추후 핸드폰으로 터치 및 줌했을 때 잘 되는지 테스트 필요합니다.

## 😡 Trouble Shooting
- categories를 통해 백엔드에서 받아온 주별 데이터 `2025-W9`데이터를 요구사항에 맞게 `00월 00주차`로 매핑하도록 해야했습니다. 하지만 xaxis.categories에 매핑이 정상적으로 되지 않는 현상(매핑된 문자가 나오지 않음, 콘솔엔 잘 찍힘)이 발생했습니다. 이유는 ApexChart가 내부적으로 options.xaxis.categories가 업데이트되더라도 리렌더링을 강제로 트리거하지 않기 때문에 발생한 문제였습니다. useMemo로 categories를 캐싱하고 있어, key로 periodType이 바뀌면 리렌더링이 되도록 작업하였습니다.
```tsx
<ApexChart
  key={periodType}
  options={chartOptions}
  series={series}
  type="area"
  height={180}
/>
```

## ☀ 스크린샷 / GIF / 화면 녹화
![May-29-2025 17-58-26](https://github.com/user-attachments/assets/af91598e-80f4-42cd-96f7-3b813dc49dea)
