### PR TITLE
feat: axios interceptor로 토큰 자동 재발급 작업

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -60,7 +60,9 @@ export const getConsumptionType = async (): Promise<ConsumptionTypeKey> => {
 
 // 로그인 API
 export const loginUser = async (data: LoginRequest): Promise<LoginResponse> => {
-  const response = await apiClient.post('/api/auth/login/password', data);
+  const response = await apiClient.post('/api/auth/login/password', data, {
+    withCredentials: true,
+  });
   return response.data;
 };
 
@@ -71,4 +73,16 @@ export const loginWithPin = async (memberId: number, pin: string): Promise<Login
     pin,
   });
   return response.data;
+};
+
+// 액세스 토큰 재발급 API
+export const postAuthToken = async () => {
+  const response = await apiClient.post<{ accessToken: string }>(
+    '/api/auth/token',
+    {},
+    {
+      withCredentials: true,
+    }
+  );
+  return response.data.accessToken;
 };

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { postAuthToken } from './auth';
+
 // 공통 설정 포함 axios 인스턴스 생성 (baseURL, JSON 헤더)
 export const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
@@ -7,3 +9,44 @@ export const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+const getAccessToken = () => localStorage.getItem('accessToken');
+const setAccessToken = (token: string) => localStorage.setItem('accessToken', token);
+
+apiClient.interceptors.request.use((config) => {
+  const token = getAccessToken();
+  if (token && config.headers) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalConfig = error.config;
+
+    if (error.response?.status === 401 && originalConfig && !originalConfig._retry) {
+      originalConfig._retry = true;
+
+      try {
+        const newAccessToken = await postAuthToken();
+        setAccessToken(newAccessToken);
+
+        return apiClient({
+          ...originalConfig,
+          headers: {
+            ...originalConfig.headers,
+            Authorization: `Bearer ${newAccessToken}`,
+          },
+        });
+      } catch (e) {
+        localStorage.removeItem('accessToken');
+        window.location.href = '/auth/login';
+        return Promise.reject(e);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/src/hooks/useLoginUser.ts
+++ b/src/hooks/useLoginUser.ts
@@ -19,7 +19,6 @@ export const useLoginUser = () => {
       const loginRes = await loginUser(form);
 
       localStorage.setItem('accessToken', loginRes.accessToken);
-      localStorage.setItem('refreshToken', loginRes.refreshToken);
 
       const [loanStatus, creditResult] = await Promise.all([
         getCustomerLoanStatus(loginRes.accessToken),


### PR DESCRIPTION
## 🔥 Related Issues

- close #62

## 💜 작업 내용

- [x] [백엔드 관련 로직 수정 PR](https://github.com/FLEX-RATE/flexrate-back/pull/118)에서 쿠키로 리프레쉬 토큰 내려주는 작업을 토대로 토큰 재발급 엔드포인트 구성
- [x]Axios 인터셉터 로직 작성


## ✅ PR Point

- 기존 로그인에서는 accessToken과 refreshToken 둘 다 로그인 성공 시, 로컬 스토리지에 저장을 해놨었습니다. 하지만 이는 토큰 재발급 앤드포인트에서도 쿠키로 받아올 수 있게끔 애초에 설계가 되어있었고, 로컬스토리지의 리프레쉬 토큰 저장은 XSS 보안 위험도 있기에 쿠키로 저장하는 방식으로 로직을 바꿨습니다. (백엔드에 쿠키로 리프레쉬 토큰을 넣어주는 로직이 없어 해당 로직 또한 수정하였습니다.)
- axios interceptors로 401에러가 뜰 시, 리프레쉬 토큰과 함께 재발급 엔드포인트로 요청해 액세스 토큰을 재발급 받을 수 있도록 하였습니다.

## 😡 Trouble Shooting

- 인터셉터 설정 후, 재발급 엔드포인트에 요청한 상태에서 401 에러가 떴을 시, 계속해서 무한루프로 axios를 재요청하는 문제가 있었습니다. 해당 재요청하는 axios 로직을 없애고 `originalConfig._retry = true;` 설정을 통해 재시도 방지를 한 후, 재요청을 진행하여 해결하였습니다.
```ts
if (error.response?.status === 401 && originalConfig && !originalConfig._retry) {
  originalConfig._retry = true;

  const newToken = await postAuthToken();

  setAccessToken(newToken);
  originalConfig.headers.Authorization = `Bearer ${newToken}`;
  return apiClient(originalConfig);
}
```

- refreshToken이 들어있는 쿠키를 서버로 전송하는 것을 허용하기 위한 `withCredentials` 설정을 true로 지정한 엔드포인트를 작성하였습니다.
```ts
export const postAuthToken = async () => {
  const response = await apiClient.post<{ accessToken: string }>(
    '/api/auth/token',
    {},
    {
      withCredentials: true,
    }
  );
  return response.data.accessToken;
};
```

## ☀ 스크린샷 / GIF / 화면 녹화

![May-30-2025 01-32-38](https://github.com/user-attachments/assets/14ab7e9b-bf8f-4daa-aaf1-0e4191310796)

