### PR TITLE
feat: 대출 보유자 메인페이지 소비 분석 리포트 버튼 추가

### DIFF
--- a/src/app/consumption-report/page.tsx
+++ b/src/app/consumption-report/page.tsx
@@ -238,6 +238,7 @@ const CircleContainer = styled.div`
 
 const ReportContainer = styled.div`
   margin-top: 52px;
+  margin-bottom: 90px;
   padding-bottom: 90px;
   display: flex;
   flex-direction: column;

--- a/src/components/Banner/Banner.style.ts
+++ b/src/components/Banner/Banner.style.ts
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 
 import { semanticColor } from '@/styles/colors';
+import { typoStyleMap } from '@/styles/typos';
 
 export const BannerContainer = styled.div<{ $borderNone?: boolean }>`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  gap: 4px;
   align-items: center;
   justify-content: center;
   border: ${({ $borderNone }) =>
@@ -16,11 +18,18 @@ export const BannerContainer = styled.div<{ $borderNone?: boolean }>`
 `;
 
 export const BannerContent = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
-  width: 255px;
-  min-width: fit-content;
+  justify-content: space-between;
+`;
+
+export const BannerTextContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
 `;
 
 interface BannerLabelProps {
@@ -36,16 +45,28 @@ export const BannerLabel = styled.div<BannerLabelProps>`
   color: ${({ $color }) => $color};
   padding: 8px 12px;
   border-radius: 14px;
-  font-size: 14px;
-  font-weight: 600;
+  ${typoStyleMap['body2_sb']}
   margin-right: 10px;
   min-width: fit-content;
 `;
 
 export const BannerDesc = styled.p`
-  font-size: 14px;
-  font-weight: 600;
+  ${typoStyleMap['body2_eb']}
   margin: 0;
   color: ${semanticColor.text.normal.primary};
   min-width: fit-content;
+`;
+
+export const ReportBtn = styled.div`
+  cursor: pointer;
+  width: 100%;
+  padding: 12px 0px 9px 0px;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid ${semanticColor.border.inactive.default};
+`;
+
+export const ReportTitle = styled.div`
+  ${typoStyleMap['caption1_m']};
+  color: ${semanticColor.text.normal.sub2};
 `;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,11 +1,21 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
-import { BannerContainer, BannerContent, BannerLabel, BannerDesc } from './Banner.style';
+import {
+  BannerContainer,
+  BannerContent,
+  BannerLabel,
+  BannerDesc,
+  BannerTextContainer,
+  ReportBtn,
+  ReportTitle,
+} from './Banner.style';
 import { BannerProps, bannerMetaMap } from './Banner.type';
 
-const Banner = ({ type, borderNone }: BannerProps) => {
+const Banner = ({ isWithReport, type, borderNone }: BannerProps) => {
+  const router = useRouter();
   const meta = type ? bannerMetaMap[type] : undefined;
 
   if (!meta) {
@@ -15,12 +25,20 @@ const Banner = ({ type, borderNone }: BannerProps) => {
   return (
     <BannerContainer $borderNone={borderNone}>
       <BannerContent>
-        <BannerLabel $bgColor={meta.bgColor} $color={meta.color}>
-          {meta.label}
-        </BannerLabel>
-        <BannerDesc>{meta.description}</BannerDesc>
+        <BannerTextContainer>
+          <BannerLabel $bgColor={meta.bgColor} $color={meta.color}>
+            {meta.label}
+          </BannerLabel>
+          <BannerDesc>{meta.description}</BannerDesc>
+        </BannerTextContainer>
+        <Image src={meta.icon} alt={`${meta.label} icon`} width={50} height={50} />
       </BannerContent>
-      <Image src={meta.icon} alt={`${meta.label} icon`} width={50} height={50} />
+      {isWithReport && (
+        <ReportBtn onClick={() => router.push('/consumption-report')}>
+          <ReportTitle>소비습관 리포트 확인하러 가기</ReportTitle>
+          <Image src={'/icons/right_slide_arrow.svg'} width={8} height={13} alt="오른쪽 화살표" />
+        </ReportBtn>
+      )}
     </BannerContainer>
   );
 };

--- a/src/components/Banner/Banner.type.ts
+++ b/src/components/Banner/Banner.type.ts
@@ -4,6 +4,7 @@ import { ConsumptionType } from '@/stores/userStore';
 import { semanticColor } from '@/styles/colors';
 
 export interface BannerProps {
+  isWithReport?: boolean;
   type?: ConsumptionType;
   borderNone?: boolean;
 }

--- a/src/components/MainHasLoan/FirstPage/FirstPage.tsx
+++ b/src/components/MainHasLoan/FirstPage/FirstPage.tsx
@@ -62,7 +62,7 @@ const FirstPage = ({ user }: { user: User | null }) => {
         </UserProductContainer>
       </BgContainer>
       <BgContainer color="gray">
-        <Banner type={user?.consumptionType} borderNone={true} />
+        <Banner type={user?.consumptionType} borderNone={true} isWithReport={true} />
         <AreaChart />
         <CardFlexContainer>
           <Card>

--- a/src/components/login/PinLogin/AddPinLogin/AddPinLogin.tsx
+++ b/src/components/login/PinLogin/AddPinLogin/AddPinLogin.tsx
@@ -5,8 +5,14 @@ import React, { useState, useMemo, useEffect } from 'react';
 import Image from 'next/image';
 
 import { registerPin } from '@/apis/auth';
-
-import { Container, Dot, DotWrapper, KeyButton, KeypadWrapper, Title } from '../PinLogin.style';
+import {
+  Container,
+  Dot,
+  DotWrapper,
+  KeyButton,
+  KeypadWrapper,
+  Title,
+} from '@/components/signup/SignupPinForm/SignupPinForm.style';
 
 const PIN_LENGTH = 6;
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #81 

## 💜 작업 내용

- [x] 대출 보유자 메인페이지 소비 분석 리포트 버튼 추가

## ✅ PR Point

- 기존 공통 컴포넌트였던 Banner 컴포넌트에 isWithReport 속성을 추가하여 분기 처리를 진행했습니다.
- 해당 버튼을 누르면 소비습관 리포트 페이지로 바로 이동합니다.
- 추가로 소비분석 리포트 페이지의 바닥 여백이 없어 추가해주었습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
![Jun-03-2025 02-06-48](https://github.com/user-attachments/assets/72ce4d24-542d-4a0b-b808-4d790eedbcda)

