### PR TITLE
fix: fix: PIN 삭제 버튼 동작하지 않던 오류 수정

### DIFF
--- a/src/components/login/LoginSelector/LoginSelector.tsx
+++ b/src/components/login/LoginSelector/LoginSelector.tsx
@@ -25,24 +25,27 @@ const LoginSelector = ({ onSelectFace, onSelectPassword }: LoginSelectorProps) =
   const router = useRouter();
 
   const handleSelectPin = async () => {
-    const accessToken = localStorage.getItem('accessToken');
-    if (!accessToken) {
-      alert('로그인이 필요합니다.');
-      router.push('/auth/login');
-      return;
-    }
 
-    try {
-      const data = await checkPinRegistered();
-      if (data) {
-        router.push('/pin/login');
-      } else {
-        router.push('/pin/register');
-      }
-    } catch (error) {
-      console.error('PIN 확인 실패:', error);
-      alert('오류가 발생했습니다.');
-    }
+    alert('간편 비밀번호 기능은 현재 개발 중입니다.');
+    
+    // const accessToken = localStorage.getItem('accessToken');
+    // if (!accessToken) {
+    //   alert('로그인이 필요합니다.');
+    //   router.push('/auth/login');
+    //   return;
+    // }
+
+    // try {
+    //   const data = await checkPinRegistered();
+    //   if (data) {
+    //     router.push('/pin/login');
+    //   } else {
+    //     router.push('/pin/register');
+    //   }
+    // } catch (error) {
+    //   console.error('PIN 확인 실패:', error);
+    //   alert('오류가 발생했습니다.');
+    // }
   };
 
   return (

--- a/src/components/signup/SignupPinForm/SignupPinForm.tsx
+++ b/src/components/signup/SignupPinForm/SignupPinForm.tsx
@@ -88,28 +88,27 @@ const SignupPinForm = ({ onComplete }: SignupPinFormProps) => {
         ))}
       </DotWrapper>
 
-      <KeypadWrapper>
-        {shuffledNumbers.map((num) => (
-          <KeyButton key={num} onClick={() => handleKeyClick(num.toString())} disabled={loading}>
-            {num}
-          </KeyButton>
-        ))}
-        <KeyButton onClick={() => handleKeyClick('reset')} disabled={loading} $isText={true}>
-          전체삭제
+    <KeypadWrapper>
+      {shuffledNumbers.map((num) => (
+        <KeyButton key={num} onClick={() => handleKeyClick(num.toString())} disabled={loading}>
+          {num}
         </KeyButton>
-        <KeyButton onClick={() => handleKeyClick('0')} disabled={loading}>
-          0
-        </KeyButton>
-        <KeyButton>
-          <Image
-            src={'/icons/deletePad.svg'}
-            onClick={() => handleKeyClick('del')}
-            alt="삭제하기"
-            width={27}
-            height={20}
-          />
-        </KeyButton>
-      </KeypadWrapper>
+      ))}
+      <KeyButton onClick={() => handleKeyClick('reset')} disabled={loading}>
+        전체삭제
+      </KeyButton>
+      <KeyButton onClick={() => handleKeyClick('0')} disabled={loading}>
+        0
+      </KeyButton>
+      <KeyButton onClick={() => handleKeyClick('del')} disabled={loading}>
+        <Image
+          src={'/icons/deletePad.svg'}
+          alt="삭제하기"
+          width={27}
+          height={20}
+        />
+      </KeyButton>
+    </KeypadWrapper>
     </Container>
   );
 };

--- a/src/components/verify/PinVerify.tsx
+++ b/src/components/verify/PinVerify.tsx
@@ -108,28 +108,27 @@ const PinVerify = () => {
         ))}
       </DotWrapper>
 
-      <KeypadWrapper>
-        {shuffledNumbers.map((num) => (
-          <KeyButton key={num} onClick={() => handleKeyClick(num.toString())} disabled={loading}>
-            {num}
-          </KeyButton>
-        ))}
-        <KeyButton onClick={() => handleKeyClick('reset')} disabled={loading}>
-          전체삭제
+    <KeypadWrapper>
+      {shuffledNumbers.map((num) => (
+        <KeyButton key={num} onClick={() => handleKeyClick(num.toString())} disabled={loading}>
+          {num}
         </KeyButton>
-        <KeyButton onClick={() => handleKeyClick('0')} disabled={loading}>
-          0
-        </KeyButton>
-        <KeyButton>
-          <Image
-            src={'/icons/deletePad.svg'}
-            onClick={() => handleKeyClick('del')}
-            alt="삭제하기"
-            width={27}
-            height={20}
-          />
-        </KeyButton>
-      </KeypadWrapper>
+      ))}
+      <KeyButton onClick={() => handleKeyClick('reset')} disabled={loading}>
+        전체삭제
+      </KeyButton>
+      <KeyButton onClick={() => handleKeyClick('0')} disabled={loading}>
+        0
+      </KeyButton>
+      <KeyButton onClick={() => handleKeyClick('del')} disabled={loading}>
+        <Image
+          src={'/icons/deletePad.svg'}
+          alt="삭제하기"
+          width={27}
+          height={20}
+        />
+      </KeyButton>
+    </KeypadWrapper>
     </Container>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues

- close #83 

## 💜 작업 내용

- [x] ~ PIN 입력 화면 삭제 버튼 클릭 이벤트 정상 작동하도록 KeyButton 자체에 onClick 핸들러 수정
- [x] ~ 간편 비밀번호 로그인 버튼 클릭 시 "현재 기능 현재 개발 중입니다" alert 추가

## ✅ PR Point
- 현재 회원가입 PIN 등록과 대출신청페이지 PIN 인증 페이지들 지우기 버튼 오류를 수정 했습니다.
- 기존에는 <Image> 영역에만 onClick이 적용이 되어 버튼의 다른 비어있는 영역 누를 때 반응하지 않는 버그가 있었습니다
- KeyButton 자체에 이벤트를 걸어서, 전체 버튼 클릭 시 삭제되도록 UX 개선했습니다
- 삭제 버튼 외 다른 숫자 키패드 동작도 함께 확인해주세요
- 간편 비밀번호 로그인 버튼 클릭 시 "개발 중입니다" 알림 추가했습니다

## 😡 Trouble Shooting

- 초기에는 삭제 아이콘 클릭만 작동하여, 키패드 UI 전체 버튼 클릭 시 반응하지 않아 UX 문제점을 확인했습니다
- 문제 원인이 이벤트 Image 내부에 있다는 걸 확인하고, KeyButton으로 바꿔 해결했습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
![image](https://github.com/user-attachments/assets/ee311651-d11e-4344-9dd1-dab1cb1248e0)
![image](https://github.com/user-attachments/assets/38445b52-ffc2-477b-9ca8-a26ef32a66f7)

