### PR TITLE
feat: 어드민 페이지 접근 권한 설정 및 로그인 라우팅 지정

### DIFF
--- a/src/components/admin/AdminLayout/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout/AdminLayout.tsx
@@ -1,10 +1,23 @@
+import NotFound from '@/app/not-found';
 import Header from '@/components/admin/Header/Header';
+import { useAuthGuard } from '@/hooks/useAuthGuard';
+import { useUserStore } from '@/stores/userStore';
 
 import Sidebar from '../Sidebar/Sidebar';
 
 import { AdminBody, AdminWrapper } from './AdminLayout.style';
 
 const AdminLayout = ({ children }: { children: React.ReactNode }) => {
+  useAuthGuard('ADMIN');
+
+  const user = useUserStore((state) => state.user);
+
+  if (!user) return null;
+
+  if (user.role !== 'ADMIN') {
+    return <NotFound />;
+  }
+
   return (
     <AdminWrapper>
       <Header />

--- a/src/components/admin/Header/Header.style.ts
+++ b/src/components/admin/Header/Header.style.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { backgroundColorMap, borderColorMap, textColorMap } from '@/components/Button/Button.type';
+import { typoStyleMap } from '@/styles/typos';
 import styled from '@emotion/styled';
 
 export const HeaderWrapper = styled.div`
@@ -59,4 +61,18 @@ export const EmailBox = styled.div`
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+`;
+
+export const LogoutBtn = styled.button`
+  cursor: pointer;
+  ${typoStyleMap['body1_sb']};
+  width: fit-content;
+  padding: 8px 16px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 7px;
+  border: 1px solid ${borderColorMap['SECONDARY']};
+  background-color: ${backgroundColorMap['SECONDARY']};
+  color: ${textColorMap['SECONDARY']};
+  font-size: 15px;
 `;

--- a/src/components/admin/Header/Header.tsx
+++ b/src/components/admin/Header/Header.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 
 import Logo from '@/assets/img/logo(blue).png';
 import { useInitUser } from '@/hooks/useInitUser';
+import { useLogout } from '@/hooks/useLogout';
 import { useUserStore } from '@/stores/userStore';
 
 import {
@@ -10,11 +11,18 @@ import {
   HeaderWrapper,
   LogoContainer,
   LogoSmallText,
+  LogoutBtn,
 } from './Header.style';
 
 const Header = () => {
   useInitUser();
   const user = useUserStore((state) => state.user);
+  const { mutate: logoutMutate } = useLogout();
+
+  const handleLogout = () => {
+    logoutMutate();
+  };
+
   return (
     <HeaderWrapper>
       <LogoContainer>
@@ -22,6 +30,7 @@ const Header = () => {
         <LogoSmallText>Admin</LogoSmallText>
       </LogoContainer>
       <HeaderRightContainer>
+        <LogoutBtn onClick={handleLogout}>로그아웃</LogoutBtn>
         {user ? <EmailBox>{user?.email}</EmailBox> : <></>}
       </HeaderRightContainer>
     </HeaderWrapper>

--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useUserStore } from '@/stores/userStore';
+
+export const useAuthGuard = (requiredRole: 'ADMIN' | 'MEMBER') => {
+  const router = useRouter();
+  const user = useUserStore((state) => state.user);
+
+  useEffect(() => {
+    if (!user) return;
+
+    if (user.role !== requiredRole) {
+      router.replace('/not-found');
+    }
+  }, [user, requiredRole, router]);
+};

--- a/src/hooks/useLoginUser.ts
+++ b/src/hooks/useLoginUser.ts
@@ -20,24 +20,33 @@ export const useLoginUser = () => {
 
       localStorage.setItem('accessToken', loginRes.accessToken);
 
-      const [loanStatus, creditResult, creditScore] = await Promise.all([
+      const [loanStatus, creditResult] = await Promise.all([
         getCustomerLoanStatus(loginRes.accessToken),
         getCreditStatus(loginRes.accessToken),
-        getCreditScore(loginRes.accessToken),
       ]);
+
+      let creditScore = null;
+      if (creditResult.creditScoreStatus) {
+        creditScore = await getCreditScore(loginRes.accessToken);
+      }
 
       return {
         username: loginRes.username,
+        role: loginRes.role,
         email: loginRes.email,
         recentLoanStatus: loanStatus,
         hasCreditScore: creditResult.creditScoreStatus,
-        creditScore: creditScore.creditScore,
+        creditScore: creditScore?.creditScore ?? 0,
       };
     },
 
     onSuccess: (fullUser) => {
       setUser(fullUser);
-      router.push('/');
+      if (fullUser.role === 'ADMIN') {
+        router.push('/admin/customer-management');
+      } else {
+        router.push('/');
+      }
     },
 
     onError: (error: unknown) => {

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -11,6 +11,7 @@ export type ConsumptionType = 'CONSERVATIVE' | 'BALANCED' | 'PRACTICAL' | 'CONSU
 
 export type User = {
   username: string;
+  role: 'MEMBER' | 'ADMIN';
   email: string;
   recentLoanStatus: LoanStatusType;
   hasCreditScore: boolean;

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -40,4 +40,5 @@ export interface LoginResponse {
   refreshToken: string;
   username: string;
   email: string;
+  role: 'MEMBER' | 'ADMIN';
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #89 

## 💜 작업 내용

- [x] admin 페이지는 admin 권한만 들어가도록(admin은 admin 로그인 회원가입 및 어드민 페이지만 들어가도록)
- [x] 로그인했을때 회원 권한이 admin으로 로그인하면 즉시 admin페이지로 이동
- [x] 어드민 로그아웃 버튼 추가

## ✅ PR Point

- 원래는 Next.js middleware를 활용해서 접근 권한 설정을 해주려고 했는데 저희는 로컬 스토리지에 액세스 토큰이 저장되어있어서 이를 서버 단인 middleware가 알아차릴 수 없기 때문에 middleware를 이용하는 대신 useEffect로 사용자 정보를 스토리지에서 확인해서 판단하는 방식으로 했습니다. 백엔드 로직을 건드릴까 하다가... 그러면 너무 크게 수정을 해야할 것 같아서 클라이언트 측에서 처리하는 방식으로 채택했습니다.
- 추가적으로 어드민 페이지에 로그아웃 버튼이 없어 이를 추가하였습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
<p>
  <img src="https://github.com/user-attachments/assets/01d4f5e9-4fb2-4fbd-81f5-e290ad9c6e99" width="45%" />
  <img src="https://github.com/user-attachments/assets/72cc7119-a29e-4e12-8166-d777f7153f20" width="45%" />
</p>